### PR TITLE
fix: added missing host and scheme properties into httpGet probe spec

### DIFF
--- a/loader/loader_test.go
+++ b/loader/loader_test.go
@@ -81,6 +81,8 @@ containers:
         port: 8080
     readinessProbe:
       httpGet:
+        host: "1.1.1.1"
+        scheme: HTTPS
         path: /ready
         port: 8080
         httpHeaders:
@@ -166,8 +168,10 @@ resources:
 						},
 						ReadinessProbe: types.ContainerProbeSpec{
 							HTTPGet: types.HTTPGetActionSpec{
-								Path: "/ready",
-								Port: 8080,
+								Host:   "1.1.1.1",
+								Scheme: "HTTPS",
+								Path:   "/ready",
+								Port:   8080,
 								HTTPHeaders: []types.HTTPHeaderSpec{
 									{Name: "Custom-Header", Value: "Awesome"},
 								},

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -190,27 +190,11 @@ const ScoreSchemaV1b1 = `
 						},
 						"livenessProbe": {
 							"description": "The liveness probe for the container.",
-                            "type": "object",
-							"minProperties": 1,
-                            "additionalProperties": false,
-                            "properties": {
-                              "httpGet": {
-                                "description": "",
-							    "$ref": "#/properties/containers/definitions/httpProbe"
-                              }
-                            }
+							"$ref": "#/properties/containers/definitions/containerProbe"
 						},
                         "readinessProbe": {
 							"description": "The readiness probe for the container.",
-							"type": "object",
-							"minProperties": 1,
-                            "additionalProperties": false,
-                            "properties": {
-                              "httpGet": {
-                                "description": "",
-							    "$ref": "#/properties/containers/definitions/httpProbe"
-                              }
-                            }
+							"$ref": "#/properties/containers/definitions/containerProbe"
 						}
 					}
 				}
@@ -232,6 +216,16 @@ const ScoreSchemaV1b1 = `
 						}
 					}
 				},
+				"containerProbe": {
+					"type": "object",
+					"minProperties": 1,
+					"additionalProperties": false,
+					"properties": {
+						"httpGet": {
+							"$ref": "#/properties/containers/definitions/httpProbe"
+						}
+					}
+				},
 				"httpProbe": {
 					"description": "An HTTP probe details.",
 					"type": "object",
@@ -240,6 +234,15 @@ const ScoreSchemaV1b1 = `
 						"path"
 					],
 					"properties": {
+						"host": {
+							"description": "Host name to connect to. Defaults to the container IP.",
+							"type": "string"
+						},
+						"scheme": {
+							"description": "Scheme to use for connecting to the host (HTTP or HTTPS). Defaults to HTTP.",
+							"type": "string",
+							"enum": ["HTTP", "HTTPS"]
+						},
 						"path": {
 							"description": "The path of the HTTP probe endpoint.",
 							"type": "string"

--- a/schema/schema_test.go
+++ b/schema/schema_test.go
@@ -949,7 +949,7 @@ func TestSchema(t *testing.T) {
 			Message: "containers.hello.livenessProbe.httpGet.scheme must be one of the following: \"HTTP\", \"HTTPS\"",
 		},
 		{
-			Name: "containers.*.livenessProbe.httpGet.path is not a string",
+			Name: "containers.*.livenessProbe.httpGet.scheme is not a string",
 			Src: func() map[string]interface{} {
 				src := newTestDocument()
 				var hello = src["containers"].(map[string]interface{})["hello"].(map[string]interface{})

--- a/schema/schema_test.go
+++ b/schema/schema_test.go
@@ -894,6 +894,72 @@ func TestSchema(t *testing.T) {
 			Message: "containers.hello.livenessProbe.httpGet: Invalid type",
 		},
 		{
+			Name: "containers.*.livenessProbe.httpGet.host is not a string",
+			Src: func() map[string]interface{} {
+				src := newTestDocument()
+				var hello = src["containers"].(map[string]interface{})["hello"].(map[string]interface{})
+				var httpGet = hello["livenessProbe"].(map[string]interface{})["httpGet"].(map[string]interface{})
+				httpGet["host"] = 12
+				return src
+			}(),
+			Message: "containers.hello.livenessProbe.httpGet.host: Invalid type",
+		},
+		{
+			Name: "containers.*.livenessProbe.httpGet.host is 1.1.1.1",
+			Src: func() map[string]interface{} {
+				src := newTestDocument()
+				var hello = src["containers"].(map[string]interface{})["hello"].(map[string]interface{})
+				var httpGet = hello["livenessProbe"].(map[string]interface{})["httpGet"].(map[string]interface{})
+				httpGet["host"] = "1.1.1.1"
+				return src
+			}(),
+			Message: "",
+		},
+		{
+			Name: "containers.*.livenessProbe.httpGet.scheme is HTTP",
+			Src: func() map[string]interface{} {
+				src := newTestDocument()
+				var hello = src["containers"].(map[string]interface{})["hello"].(map[string]interface{})
+				var httpGet = hello["livenessProbe"].(map[string]interface{})["httpGet"].(map[string]interface{})
+				httpGet["scheme"] = "HTTP"
+				return src
+			}(),
+			Message: "",
+		},
+		{
+			Name: "containers.*.livenessProbe.httpGet.scheme is HTTPS",
+			Src: func() map[string]interface{} {
+				src := newTestDocument()
+				var hello = src["containers"].(map[string]interface{})["hello"].(map[string]interface{})
+				var httpGet = hello["livenessProbe"].(map[string]interface{})["httpGet"].(map[string]interface{})
+				httpGet["scheme"] = "HTTP"
+				return src
+			}(),
+			Message: "",
+		},
+		{
+			Name: "containers.*.livenessProbe.httpGet.scheme is TCP",
+			Src: func() map[string]interface{} {
+				src := newTestDocument()
+				var hello = src["containers"].(map[string]interface{})["hello"].(map[string]interface{})
+				var httpGet = hello["livenessProbe"].(map[string]interface{})["httpGet"].(map[string]interface{})
+				httpGet["scheme"] = "TCP"
+				return src
+			}(),
+			Message: "containers.hello.livenessProbe.httpGet.scheme must be one of the following: \"HTTP\", \"HTTPS\"",
+		},
+		{
+			Name: "containers.*.livenessProbe.httpGet.path is not a string",
+			Src: func() map[string]interface{} {
+				src := newTestDocument()
+				var hello = src["containers"].(map[string]interface{})["hello"].(map[string]interface{})
+				var httpGet = hello["livenessProbe"].(map[string]interface{})["httpGet"].(map[string]interface{})
+				httpGet["scheme"] = 12
+				return src
+			}(),
+			Message: "containers.hello.livenessProbe.httpGet.scheme: Invalid type",
+		},
+		{
 			Name: "containers.*.livenessProbe.httpGet.path is missing",
 			Src: func() map[string]interface{} {
 				src := newTestDocument()

--- a/types/containers.go
+++ b/types/containers.go
@@ -46,13 +46,7 @@ type VolumeMountSpec struct {
 
 // ContainerProbeSpec is a container probe specification.
 type ContainerProbeSpec struct {
-	HTTPGet                       HTTPGetActionSpec `json:"httpGet"`
-	InitialDelaySeconds           int32             `json:"initialDelaySeconds"`
-	TimeoutSeconds                int32             `json:"timeoutSeconds"`
-	PeriodSeconds                 int32             `json:"periodSeconds"`
-	SuccessThreshold              int32             `json:"successThreshold"`
-	FailureThreshold              int32             `json:"failureThreshold"`
-	TerminationGracePeriodSeconds int64             `json:"terminationGracePeriodSeconds"`
+	HTTPGet HTTPGetActionSpec `json:"httpGet"`
 }
 
 // HTTPGetActionSpec is an HTTP GET Action specification.


### PR DESCRIPTION
Added missing `host` and `scheme` properties into `httpGet` probe spec

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New chore (expected functionality to be implemented)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [x] I've signed off with an email address that matches the commit author.
