### PR TITLE
fixed: go module path for v1

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,10 +5,10 @@ Reference library for the parsing and loading SCORE files in Go.
 This can be added to your project via:
 
 ```sh
-$ go get -u github.com/score-spec/score-go/v1
+$ go get -u github.com/score-spec/score-go
 ```
 
-**NOTE**: if you project is still using the hand-written types, you will need to stay on `github.com/score-spec/score-go`
+**NOTE**: if you project is still using the hand-written types, you will need to stay on `github.com/score-spec/score-go@v0.0.1`
 and any important fixes to the schema may be back-ported to that branch.
 
 ## Parsing SCORE files

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/score-spec/score-go/v1
+module github.com/score-spec/score-go
 
 go 1.21
 

--- a/loader/loader.go
+++ b/loader/loader.go
@@ -14,7 +14,7 @@ import (
 	"github.com/mitchellh/mapstructure"
 	"gopkg.in/yaml.v3"
 
-	"github.com/score-spec/score-go/v1/types"
+	"github.com/score-spec/score-go/types"
 )
 
 // ParseYAML parses YAML into the target mapping structure.

--- a/loader/loader_test.go
+++ b/loader/loader_test.go
@@ -15,7 +15,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	"github.com/score-spec/score-go/v1/types"
+	"github.com/score-spec/score-go/types"
 )
 
 func stringRef(input string) *string {


### PR DESCRIPTION
This fixues up the go module path for v1. It turns out go modules only support the /vX suffix for version 2 and higher. 

So for now we've tagged an explicit v0 tag and we'll keep the same module path as before but with tags > v1.