### PR TITLE
fix: fixed generated types for workload and resource metadata

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,6 @@
 
 # Dependency directories (remove the comment below to include it)
 # vendor/
+
+# Temporary modified schema
+schema/files/score-v1b1.json.modified

--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,7 @@ default:
 update-schema:
 	rm -fv schema/files/score-v1b1.json.modified
 	git subtree pull --prefix schema/files git@github.com:score-spec/schema.git main --squash -m "chore: updated score specification"
+	git log -1 --pretty=%B | grep "chore: updated score specification" && git commit --amend -s --no-edit
 
 ## Generate types
 .PHONY: generate

--- a/Makefile
+++ b/Makefile
@@ -10,8 +10,8 @@ default:
 .PHONY: update-schema
 update-schema:
 	rm -fv schema/files/score-v1b1.json.modified
-	git subtree pull --prefix schema/files git@github.com:score-spec/schema.git main --squash -m "chore: updated score specification"
-	git log -1 --pretty=%B | grep "chore: updated score specification" && git commit --amend -s --no-edit
+	C=$(shell git rev-parse HEAD); git subtree pull --prefix schema/files git@github.com:score-spec/schema.git main --squash -m "chore: updated score specification"; \
+		if git rev-parse HEAD | grep -v $$C; then git commit --amend -s --no-edit; fi
 
 ## Generate types
 .PHONY: generate

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,20 @@
+# Disable all the default make stuff
+MAKEFLAGS += --no-builtin-rules
+.SUFFIXES:
+
+.PHONY: .ALWAYS
+.ALWAYS:
+
+## Update score schema
+.PHONY: update-schema
+update-schema:
+	rm -fv schema/files/score-v1b1.json.modified
+	git subtree pull --prefix schema/files git@github.com:score-spec/schema.git main --squash
+
+## Generate types
+.PHONY: generate
+generate:
+# Unfortunately struct generators don't know how to handle mixed properties and additional properties so we have to strip these out before we generate the structs.
+# We still validate with the original specification though.
+	jq 'walk(if type == "object" and .type == "object" and .additionalProperties == true and (.properties | type) == "object" then (del(.required) | del(.properties)) else . end)' schema/files/score-v1b1.json > schema/files/score-v1b1.json.modified
+	go generate -v ./...

--- a/Makefile
+++ b/Makefile
@@ -2,14 +2,15 @@
 MAKEFLAGS += --no-builtin-rules
 .SUFFIXES:
 
-.PHONY: .ALWAYS
-.ALWAYS:
+.PHONY: default
+default:
+	# Please provide a valid make target
 
 ## Update score schema
 .PHONY: update-schema
 update-schema:
 	rm -fv schema/files/score-v1b1.json.modified
-	git subtree pull --prefix schema/files git@github.com:score-spec/schema.git main --squash
+	git subtree pull --prefix schema/files git@github.com:score-spec/schema.git main --squash -m "chore: updated score specification"
 
 ## Generate types
 .PHONY: generate

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ When the Score JSON schema is updated in https://github.com/score-spec/schema, t
 First update the subtree:
 
 ```
-git subtree pull --prefix schema/files git@github.com:score-spec/schema.git main --squash
+make update-schema
 ```
 
 Then regenerate the defined types:

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ git subtree pull --prefix schema/files git@github.com:score-spec/schema.git main
 Then regenerate the defined types:
 
 ```
-go generate -v ./...
+make generate
 ```
 
 And ensure the tests still pass:

--- a/loader/loader_test.go
+++ b/loader/loader_test.go
@@ -133,7 +133,7 @@ resources:
 			Output: types.Workload{
 				ApiVersion: "score.dev/v1b1",
 				Metadata: types.WorkloadMetadata{
-					Name: "hello-world",
+					"name": "hello-world",
 				},
 				Service: &types.WorkloadService{
 					Ports: types.WorkloadServicePorts{
@@ -205,8 +205,8 @@ resources:
 					"db": {
 						Type:  "postgres",
 						Class: stringRef("large"),
-						Metadata: &types.ResourceMetadata{
-							Annotations: map[string]string{
+						Metadata: map[string]interface{}{
+							"annotations": map[string]interface{}{
 								"my.org/version": "0.1",
 							},
 						},

--- a/schema/validate_test.go
+++ b/schema/validate_test.go
@@ -381,3 +381,20 @@ func TestValidateJson_Error(t *testing.T) {
 	err := ValidateJson(bytes.NewReader(source))
 	assert.Error(t, err)
 }
+
+func TestValidateYaml_missing_workload_name(t *testing.T) {
+	var source = []byte(`
+---
+apiVersion: score.dev/v1b1
+metadata:
+  no-name: hello-world
+  something-else: value
+
+containers:
+  hello:
+    image: busybox
+`)
+
+	err := ValidateYaml(bytes.NewReader(source))
+	assert.EqualError(t, err, "jsonschema: '/metadata' does not validate with https://score.dev/schemas/score#/properties/metadata/required: missing properties: 'name'")
+}

--- a/types/types.gen.go
+++ b/types/types.gen.go
@@ -116,79 +116,110 @@ type HttpProbeScheme string
 const HttpProbeSchemeHTTP HttpProbeScheme = "HTTP"
 const HttpProbeSchemeHTTPS HttpProbeScheme = "HTTPS"
 
-// The resource name.
-type Resource struct {
-	// A specialisation of the resource type.
-	Class *string `json:"class,omitempty" yaml:"class,omitempty" mapstructure:"class,omitempty"`
-
-	// The metadata for the resource.
-	Metadata *ResourceMetadata `json:"metadata,omitempty" yaml:"metadata,omitempty" mapstructure:"metadata,omitempty"`
-
-	// The parameters used to validate or provision the resource in the environment.
-	Params ResourceParams `json:"params,omitempty" yaml:"params,omitempty" mapstructure:"params,omitempty"`
-
-	// The resource in the target environment.
-	Type string `json:"type" yaml:"type" mapstructure:"type"`
+// UnmarshalJSON implements json.Unmarshaler.
+func (j *Resource) UnmarshalJSON(b []byte) error {
+	var raw map[string]interface{}
+	if err := json.Unmarshal(b, &raw); err != nil {
+		return err
+	}
+	if v, ok := raw["type"]; !ok || v == nil {
+		return fmt.Errorf("field type in Resource: required")
+	}
+	type Plain Resource
+	var plain Plain
+	if err := json.Unmarshal(b, &plain); err != nil {
+		return err
+	}
+	*j = Resource(plain)
+	return nil
 }
 
-// The metadata for the resource.
-type ResourceMetadata struct {
-	// Annotations that apply to the property.
-	Annotations ResourceMetadataAnnotations `json:"annotations,omitempty" yaml:"annotations,omitempty" mapstructure:"annotations,omitempty"`
+// UnmarshalJSON implements json.Unmarshaler.
+func (j *HttpProbe) UnmarshalJSON(b []byte) error {
+	var raw map[string]interface{}
+	if err := json.Unmarshal(b, &raw); err != nil {
+		return err
+	}
+	if v, ok := raw["path"]; !ok || v == nil {
+		return fmt.Errorf("field path in HttpProbe: required")
+	}
+	type Plain HttpProbe
+	var plain Plain
+	if err := json.Unmarshal(b, &plain); err != nil {
+		return err
+	}
+	if plain.HttpHeaders != nil && len(plain.HttpHeaders) < 1 {
+		return fmt.Errorf("field %s length: must be >= %d", "httpHeaders", 1)
+	}
+	*j = HttpProbe(plain)
+	return nil
 }
 
-// Annotations that apply to the property.
-type ResourceMetadataAnnotations map[string]string
-
-// The parameters used to validate or provision the resource in the environment.
-type ResourceParams map[string]interface{}
-
-// The compute resources limits.
-type ResourcesLimits struct {
-	// The CPU limit.
-	Cpu *string `json:"cpu,omitempty" yaml:"cpu,omitempty" mapstructure:"cpu,omitempty"`
-
-	// The memory limit.
-	Memory *string `json:"memory,omitempty" yaml:"memory,omitempty" mapstructure:"memory,omitempty"`
+// UnmarshalJSON implements json.Unmarshaler.
+func (j *HttpProbeScheme) UnmarshalJSON(b []byte) error {
+	var v string
+	if err := json.Unmarshal(b, &v); err != nil {
+		return err
+	}
+	var ok bool
+	for _, expected := range enumValues_HttpProbeScheme {
+		if reflect.DeepEqual(v, expected) {
+			ok = true
+			break
+		}
+	}
+	if !ok {
+		return fmt.Errorf("invalid value (expected one of %#v): %#v", enumValues_HttpProbeScheme, v)
+	}
+	*j = HttpProbeScheme(v)
+	return nil
 }
 
-// The network port description.
-type ServicePort struct {
-	// The public service port.
-	Port int `json:"port" yaml:"port" mapstructure:"port"`
-
-	// The transport level protocol. Defaults to TCP.
-	Protocol *string `json:"protocol,omitempty" yaml:"protocol,omitempty" mapstructure:"protocol,omitempty"`
-
-	// The internal service port. This will default to 'port' if not provided.
-	TargetPort *int `json:"targetPort,omitempty" yaml:"targetPort,omitempty" mapstructure:"targetPort,omitempty"`
+var enumValues_HttpProbeScheme = []interface{}{
+	"HTTP",
+	"HTTPS",
 }
 
-// Score workload specification
-type Workload struct {
-	// The declared Score Specification version.
-	ApiVersion string `json:"apiVersion" yaml:"apiVersion" mapstructure:"apiVersion"`
-
-	// The declared Score Specification version.
-	Containers WorkloadContainers `json:"containers" yaml:"containers" mapstructure:"containers"`
-
-	// The metadata description of the Workload.
-	Metadata WorkloadMetadata `json:"metadata" yaml:"metadata" mapstructure:"metadata"`
-
-	// The dependencies needed by the Workload.
-	Resources WorkloadResources `json:"resources,omitempty" yaml:"resources,omitempty" mapstructure:"resources,omitempty"`
-
-	// The service that the workload provides.
-	Service *WorkloadService `json:"service,omitempty" yaml:"service,omitempty" mapstructure:"service,omitempty"`
+// UnmarshalJSON implements json.Unmarshaler.
+func (j *ContainerVolumesElem) UnmarshalJSON(b []byte) error {
+	var raw map[string]interface{}
+	if err := json.Unmarshal(b, &raw); err != nil {
+		return err
+	}
+	if v, ok := raw["source"]; !ok || v == nil {
+		return fmt.Errorf("field source in ContainerVolumesElem: required")
+	}
+	if v, ok := raw["target"]; !ok || v == nil {
+		return fmt.Errorf("field target in ContainerVolumesElem: required")
+	}
+	type Plain ContainerVolumesElem
+	var plain Plain
+	if err := json.Unmarshal(b, &plain); err != nil {
+		return err
+	}
+	*j = ContainerVolumesElem(plain)
+	return nil
 }
 
-// The declared Score Specification version.
-type WorkloadContainers map[string]Container
-
-// The metadata description of the Workload.
-type WorkloadMetadata struct {
-	// A string that can describe the Workload.
-	Name string `json:"name" yaml:"name" mapstructure:"name"`
+// UnmarshalJSON implements json.Unmarshaler.
+func (j *ContainerFilesElem) UnmarshalJSON(b []byte) error {
+	var raw map[string]interface{}
+	if err := json.Unmarshal(b, &raw); err != nil {
+		return err
+	}
+	if v, ok := raw["target"]; !ok || v == nil {
+		return fmt.Errorf("field target in ContainerFilesElem: required")
+	}
+	type Plain ContainerFilesElem
+	var plain Plain
+	if err := json.Unmarshal(b, &plain); err != nil {
+		return err
+	}
+	if plain.Source != nil && len(*plain.Source) < 1 {
+		return fmt.Errorf("field %s length: must be >= %d", "source", 1)
+	}
+	*j = ContainerFilesElem(plain)
+	return nil
 }
 
 // UnmarshalJSON implements json.Unmarshaler.
@@ -221,89 +252,46 @@ func (j *Container) UnmarshalJSON(b []byte) error {
 	return nil
 }
 
-// UnmarshalJSON implements json.Unmarshaler.
-func (j *HttpProbe) UnmarshalJSON(b []byte) error {
-	var raw map[string]interface{}
-	if err := json.Unmarshal(b, &raw); err != nil {
-		return err
-	}
-	if v, ok := raw["path"]; !ok || v == nil {
-		return fmt.Errorf("field path in HttpProbe: required")
-	}
-	type Plain HttpProbe
-	var plain Plain
-	if err := json.Unmarshal(b, &plain); err != nil {
-		return err
-	}
-	if plain.HttpHeaders != nil && len(plain.HttpHeaders) < 1 {
-		return fmt.Errorf("field %s length: must be >= %d", "httpHeaders", 1)
-	}
-	*j = HttpProbe(plain)
-	return nil
+// The metadata for the resource.
+type ResourceMetadata map[string]interface{}
+
+// The parameters used to validate or provision the resource in the environment.
+type ResourceParams map[string]interface{}
+
+// The resource name.
+type Resource struct {
+	// A specialisation of the resource type.
+	Class *string `json:"class,omitempty" yaml:"class,omitempty" mapstructure:"class,omitempty"`
+
+	// The metadata for the resource.
+	Metadata ResourceMetadata `json:"metadata,omitempty" yaml:"metadata,omitempty" mapstructure:"metadata,omitempty"`
+
+	// The parameters used to validate or provision the resource in the environment.
+	Params ResourceParams `json:"params,omitempty" yaml:"params,omitempty" mapstructure:"params,omitempty"`
+
+	// The resource in the target environment.
+	Type string `json:"type" yaml:"type" mapstructure:"type"`
 }
 
-// UnmarshalJSON implements json.Unmarshaler.
-func (j *Resource) UnmarshalJSON(b []byte) error {
-	var raw map[string]interface{}
-	if err := json.Unmarshal(b, &raw); err != nil {
-		return err
-	}
-	if v, ok := raw["type"]; !ok || v == nil {
-		return fmt.Errorf("field type in Resource: required")
-	}
-	type Plain Resource
-	var plain Plain
-	if err := json.Unmarshal(b, &plain); err != nil {
-		return err
-	}
-	*j = Resource(plain)
-	return nil
+// The compute resources limits.
+type ResourcesLimits struct {
+	// The CPU limit.
+	Cpu *string `json:"cpu,omitempty" yaml:"cpu,omitempty" mapstructure:"cpu,omitempty"`
+
+	// The memory limit.
+	Memory *string `json:"memory,omitempty" yaml:"memory,omitempty" mapstructure:"memory,omitempty"`
 }
 
-var enumValues_HttpProbeScheme = []interface{}{
-	"HTTP",
-	"HTTPS",
-}
+// The network port description.
+type ServicePort struct {
+	// The public service port.
+	Port int `json:"port" yaml:"port" mapstructure:"port"`
 
-// UnmarshalJSON implements json.Unmarshaler.
-func (j *HttpProbeScheme) UnmarshalJSON(b []byte) error {
-	var v string
-	if err := json.Unmarshal(b, &v); err != nil {
-		return err
-	}
-	var ok bool
-	for _, expected := range enumValues_HttpProbeScheme {
-		if reflect.DeepEqual(v, expected) {
-			ok = true
-			break
-		}
-	}
-	if !ok {
-		return fmt.Errorf("invalid value (expected one of %#v): %#v", enumValues_HttpProbeScheme, v)
-	}
-	*j = HttpProbeScheme(v)
-	return nil
-}
+	// The transport level protocol. Defaults to TCP.
+	Protocol *string `json:"protocol,omitempty" yaml:"protocol,omitempty" mapstructure:"protocol,omitempty"`
 
-// UnmarshalJSON implements json.Unmarshaler.
-func (j *ContainerVolumesElem) UnmarshalJSON(b []byte) error {
-	var raw map[string]interface{}
-	if err := json.Unmarshal(b, &raw); err != nil {
-		return err
-	}
-	if v, ok := raw["source"]; !ok || v == nil {
-		return fmt.Errorf("field source in ContainerVolumesElem: required")
-	}
-	if v, ok := raw["target"]; !ok || v == nil {
-		return fmt.Errorf("field target in ContainerVolumesElem: required")
-	}
-	type Plain ContainerVolumesElem
-	var plain Plain
-	if err := json.Unmarshal(b, &plain); err != nil {
-		return err
-	}
-	*j = ContainerVolumesElem(plain)
-	return nil
+	// The internal service port. This will default to 'port' if not provided.
+	TargetPort *int `json:"targetPort,omitempty" yaml:"targetPort,omitempty" mapstructure:"targetPort,omitempty"`
 }
 
 // UnmarshalJSON implements json.Unmarshaler.
@@ -324,29 +312,17 @@ func (j *ServicePort) UnmarshalJSON(b []byte) error {
 	return nil
 }
 
-// List of network ports published by the service.
-type WorkloadServicePorts map[string]ServicePort
+// The declared Score Specification version.
+type WorkloadContainers map[string]Container
+
+// The metadata description of the Workload.
+type WorkloadMetadata map[string]interface{}
 
 // The dependencies needed by the Workload.
 type WorkloadResources map[string]Resource
 
-// UnmarshalJSON implements json.Unmarshaler.
-func (j *WorkloadMetadata) UnmarshalJSON(b []byte) error {
-	var raw map[string]interface{}
-	if err := json.Unmarshal(b, &raw); err != nil {
-		return err
-	}
-	if v, ok := raw["name"]; !ok || v == nil {
-		return fmt.Errorf("field name in WorkloadMetadata: required")
-	}
-	type Plain WorkloadMetadata
-	var plain Plain
-	if err := json.Unmarshal(b, &plain); err != nil {
-		return err
-	}
-	*j = WorkloadMetadata(plain)
-	return nil
-}
+// List of network ports published by the service.
+type WorkloadServicePorts map[string]ServicePort
 
 // The service that the workload provides.
 type WorkloadService struct {
@@ -354,25 +330,22 @@ type WorkloadService struct {
 	Ports WorkloadServicePorts `json:"ports,omitempty" yaml:"ports,omitempty" mapstructure:"ports,omitempty"`
 }
 
-// UnmarshalJSON implements json.Unmarshaler.
-func (j *ContainerFilesElem) UnmarshalJSON(b []byte) error {
-	var raw map[string]interface{}
-	if err := json.Unmarshal(b, &raw); err != nil {
-		return err
-	}
-	if v, ok := raw["target"]; !ok || v == nil {
-		return fmt.Errorf("field target in ContainerFilesElem: required")
-	}
-	type Plain ContainerFilesElem
-	var plain Plain
-	if err := json.Unmarshal(b, &plain); err != nil {
-		return err
-	}
-	if plain.Source != nil && len(*plain.Source) < 1 {
-		return fmt.Errorf("field %s length: must be >= %d", "source", 1)
-	}
-	*j = ContainerFilesElem(plain)
-	return nil
+// Score workload specification
+type Workload struct {
+	// The declared Score Specification version.
+	ApiVersion string `json:"apiVersion" yaml:"apiVersion" mapstructure:"apiVersion"`
+
+	// The declared Score Specification version.
+	Containers WorkloadContainers `json:"containers" yaml:"containers" mapstructure:"containers"`
+
+	// The metadata description of the Workload.
+	Metadata WorkloadMetadata `json:"metadata" yaml:"metadata" mapstructure:"metadata"`
+
+	// The dependencies needed by the Workload.
+	Resources WorkloadResources `json:"resources,omitempty" yaml:"resources,omitempty" mapstructure:"resources,omitempty"`
+
+	// The service that the workload provides.
+	Service *WorkloadService `json:"service,omitempty" yaml:"service,omitempty" mapstructure:"service,omitempty"`
 }
 
 // UnmarshalJSON implements json.Unmarshaler.

--- a/types/types.go
+++ b/types/types.go
@@ -1,3 +1,3 @@
 package types
 
-//go:generate go run github.com/atombender/go-jsonschema@v0.14.1 -v --schema-output=https://score.dev/schemas/score=types.gen.go --schema-package=https://score.dev/schemas/score=types --schema-root-type=https://score.dev/schemas/score=Workload ../schema/files/score-v1b1.json
+//go:generate go run github.com/atombender/go-jsonschema@v0.15.0 -v --schema-output=https://score.dev/schemas/score=types.gen.go --schema-package=https://score.dev/schemas/score=types --schema-root-type=https://score.dev/schemas/score=Workload ../schema/files/score-v1b1.json.modified


### PR DESCRIPTION
The generated types for `metadata` and `resource.*.metadata` were broken because the code generator ignored the `additionalProperties` and instead generated concrete types without any support for additional metadata entries.

Unfortunately we need the best of both worlds: an arbitrary map, while still checking for required properties during validation.

To fix this we generate the types from a 'modified' version of the spec in which we treat it like a generic map[string]interface{}. This 'modified' version is generated from a Makefile which also allows us to better codify the update-schema process.

The validation continues to use the raw spec file which can validate the required fields within the arbitrary object.

This library will then be imported into score-compose and any other score implementations that can consume it.

#### Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] New chore (expected functionality to be implemented)

#### Checklist:
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [X] I've signed off with an email address that matches the commit author.
