### PR TITLE
Updated score schema for http probe headers and updated tests to match

### DIFF
--- a/loader/loader_test.go
+++ b/loader/loader_test.go
@@ -190,7 +190,7 @@ resources:
 								Path:   "/ready",
 								Port:   8080,
 								HttpHeaders: []types.HttpProbeHttpHeadersElem{
-									{Name: stringRef("Custom-Header"), Value: stringRef("Awesome")},
+									{Name: "Custom-Header", Value: "Awesome"},
 								},
 							},
 						},

--- a/schema/files/score-v1b1.json
+++ b/schema/files/score-v1b1.json
@@ -340,7 +340,8 @@
       "properties": {
         "host": {
           "description": "Host name to connect to. Defaults to the workload IP. The is equivalent to a Host HTTP header.",
-          "type": "string"
+          "type": "string",
+          "minLength": 1
         },
         "scheme": {
           "description": "Scheme to use for connecting to the host (HTTP or HTTPS). Defaults to HTTP.",
@@ -366,6 +367,10 @@
           "items": {
             "type": "object",
             "additionalProperties": false,
+            "required": [
+              "name",
+              "value"
+            ],
             "properties": {
               "name": {
                 "description": "The HTTP header name.",
@@ -374,7 +379,8 @@
               },
               "value": {
                 "description": "The HTTP header value.",
-                "type": "string"
+                "type": "string",
+                "minLength": 1
               }
             }
           }

--- a/types/types.gen.go
+++ b/types/types.gen.go
@@ -6,233 +6,6 @@ import "encoding/json"
 import "fmt"
 import "reflect"
 
-// UnmarshalJSON implements json.Unmarshaler.
-func (j *Container) UnmarshalJSON(b []byte) error {
-	var raw map[string]interface{}
-	if err := json.Unmarshal(b, &raw); err != nil {
-		return err
-	}
-	if v, ok := raw["image"]; !ok || v == nil {
-		return fmt.Errorf("field image in Container: required")
-	}
-	type Plain Container
-	var plain Plain
-	if err := json.Unmarshal(b, &plain); err != nil {
-		return err
-	}
-	if len(plain.Image) < 1 {
-		return fmt.Errorf("field %s length: must be >= %d", "image", 1)
-	}
-	*j = Container(plain)
-	return nil
-}
-
-// The network port description.
-type ServicePort struct {
-	// The public service port.
-	Port int `json:"port" yaml:"port" mapstructure:"port"`
-
-	// The transport level protocol. Defaults to TCP.
-	Protocol *ServicePortProtocol `json:"protocol,omitempty" yaml:"protocol,omitempty" mapstructure:"protocol,omitempty"`
-
-	// The internal service port. This will default to 'port' if not provided.
-	TargetPort *int `json:"targetPort,omitempty" yaml:"targetPort,omitempty" mapstructure:"targetPort,omitempty"`
-}
-
-type HttpProbeHttpHeadersElem struct {
-	// The HTTP header name.
-	Name *string `json:"name,omitempty" yaml:"name,omitempty" mapstructure:"name,omitempty"`
-
-	// The HTTP header value.
-	Value *string `json:"value,omitempty" yaml:"value,omitempty" mapstructure:"value,omitempty"`
-}
-
-type ContainerFilesElem struct {
-	// The inline content for the file.
-	Content *string `json:"content,omitempty" yaml:"content,omitempty" mapstructure:"content,omitempty"`
-
-	// The optional file access mode in octal encoding. For example 0600.
-	Mode *string `json:"mode,omitempty" yaml:"mode,omitempty" mapstructure:"mode,omitempty"`
-
-	// If set to true, the placeholders expansion will not occur in the contents of
-	// the file.
-	NoExpand *bool `json:"noExpand,omitempty" yaml:"noExpand,omitempty" mapstructure:"noExpand,omitempty"`
-
-	// The relative or absolute path to the content file.
-	Source *string `json:"source,omitempty" yaml:"source,omitempty" mapstructure:"source,omitempty"`
-
-	// The file path to expose in the container.
-	Target string `json:"target" yaml:"target" mapstructure:"target"`
-}
-
-// UnmarshalJSON implements json.Unmarshaler.
-func (j *Workload) UnmarshalJSON(b []byte) error {
-	var raw map[string]interface{}
-	if err := json.Unmarshal(b, &raw); err != nil {
-		return err
-	}
-	if v, ok := raw["apiVersion"]; !ok || v == nil {
-		return fmt.Errorf("field apiVersion in Workload: required")
-	}
-	if v, ok := raw["containers"]; !ok || v == nil {
-		return fmt.Errorf("field containers in Workload: required")
-	}
-	if v, ok := raw["metadata"]; !ok || v == nil {
-		return fmt.Errorf("field metadata in Workload: required")
-	}
-	type Plain Workload
-	var plain Plain
-	if err := json.Unmarshal(b, &plain); err != nil {
-		return err
-	}
-	*j = Workload(plain)
-	return nil
-}
-
-// UnmarshalJSON implements json.Unmarshaler.
-func (j *HttpProbeScheme) UnmarshalJSON(b []byte) error {
-	var v string
-	if err := json.Unmarshal(b, &v); err != nil {
-		return err
-	}
-	var ok bool
-	for _, expected := range enumValues_HttpProbeScheme {
-		if reflect.DeepEqual(v, expected) {
-			ok = true
-			break
-		}
-	}
-	if !ok {
-		return fmt.Errorf("invalid value (expected one of %#v): %#v", enumValues_HttpProbeScheme, v)
-	}
-	*j = HttpProbeScheme(v)
-	return nil
-}
-
-const HttpProbeSchemeHTTP HttpProbeScheme = "HTTP"
-const HttpProbeSchemeHTTPS HttpProbeScheme = "HTTPS"
-
-// An HTTP probe details.
-type HttpProbe struct {
-	// Host name to connect to. Defaults to the workload IP. The is equivalent to a
-	// Host HTTP header.
-	Host *string `json:"host,omitempty" yaml:"host,omitempty" mapstructure:"host,omitempty"`
-
-	// Additional HTTP headers to send with the request
-	HttpHeaders []HttpProbeHttpHeadersElem `json:"httpHeaders,omitempty" yaml:"httpHeaders,omitempty" mapstructure:"httpHeaders,omitempty"`
-
-	// The path to access on the HTTP server.
-	Path string `json:"path" yaml:"path" mapstructure:"path"`
-
-	// The port to access on the workload.
-	Port int `json:"port" yaml:"port" mapstructure:"port"`
-
-	// Scheme to use for connecting to the host (HTTP or HTTPS). Defaults to HTTP.
-	Scheme *HttpProbeScheme `json:"scheme,omitempty" yaml:"scheme,omitempty" mapstructure:"scheme,omitempty"`
-}
-
-// UnmarshalJSON implements json.Unmarshaler.
-func (j *HttpProbe) UnmarshalJSON(b []byte) error {
-	var raw map[string]interface{}
-	if err := json.Unmarshal(b, &raw); err != nil {
-		return err
-	}
-	if v, ok := raw["path"]; !ok || v == nil {
-		return fmt.Errorf("field path in HttpProbe: required")
-	}
-	if v, ok := raw["port"]; !ok || v == nil {
-		return fmt.Errorf("field port in HttpProbe: required")
-	}
-	type Plain HttpProbe
-	var plain Plain
-	if err := json.Unmarshal(b, &plain); err != nil {
-		return err
-	}
-	*j = HttpProbe(plain)
-	return nil
-}
-
-type ContainerProbe struct {
-	// HttpGet corresponds to the JSON schema field "httpGet".
-	HttpGet HttpProbe `json:"httpGet" yaml:"httpGet" mapstructure:"httpGet"`
-}
-
-// UnmarshalJSON implements json.Unmarshaler.
-func (j *ContainerProbe) UnmarshalJSON(b []byte) error {
-	var raw map[string]interface{}
-	if err := json.Unmarshal(b, &raw); err != nil {
-		return err
-	}
-	if v, ok := raw["httpGet"]; !ok || v == nil {
-		return fmt.Errorf("field httpGet in ContainerProbe: required")
-	}
-	type Plain ContainerProbe
-	var plain Plain
-	if err := json.Unmarshal(b, &plain); err != nil {
-		return err
-	}
-	*j = ContainerProbe(plain)
-	return nil
-}
-
-// The compute and memory resource limits.
-type ResourcesLimits struct {
-	// The CPU limit as whole or fractional CPUs. 'm' indicates milli-CPUs. For
-	// example 2 or 125m.
-	Cpu *string `json:"cpu,omitempty" yaml:"cpu,omitempty" mapstructure:"cpu,omitempty"`
-
-	// The memory limit in bytes with optional unit specifier. For example 125M or
-	// 1Gi.
-	Memory *string `json:"memory,omitempty" yaml:"memory,omitempty" mapstructure:"memory,omitempty"`
-}
-
-// The compute resources for the container.
-type ContainerResources struct {
-	// The maximum allowed resources for the container.
-	Limits *ResourcesLimits `json:"limits,omitempty" yaml:"limits,omitempty" mapstructure:"limits,omitempty"`
-
-	// The minimal resources required for the container.
-	Requests *ResourcesLimits `json:"requests,omitempty" yaml:"requests,omitempty" mapstructure:"requests,omitempty"`
-}
-
-// The environment variables for the container.
-type ContainerVariables map[string]string
-
-type ContainerVolumesElem struct {
-	// An optional sub path in the volume.
-	Path *string `json:"path,omitempty" yaml:"path,omitempty" mapstructure:"path,omitempty"`
-
-	// Indicates if the volume should be mounted in a read-only mode.
-	ReadOnly *bool `json:"readOnly,omitempty" yaml:"readOnly,omitempty" mapstructure:"readOnly,omitempty"`
-
-	// The external volume reference.
-	Source string `json:"source" yaml:"source" mapstructure:"source"`
-
-	// The target mount on the container.
-	Target string `json:"target" yaml:"target" mapstructure:"target"`
-}
-
-// UnmarshalJSON implements json.Unmarshaler.
-func (j *ContainerVolumesElem) UnmarshalJSON(b []byte) error {
-	var raw map[string]interface{}
-	if err := json.Unmarshal(b, &raw); err != nil {
-		return err
-	}
-	if v, ok := raw["source"]; !ok || v == nil {
-		return fmt.Errorf("field source in ContainerVolumesElem: required")
-	}
-	if v, ok := raw["target"]; !ok || v == nil {
-		return fmt.Errorf("field target in ContainerVolumesElem: required")
-	}
-	type Plain ContainerVolumesElem
-	var plain Plain
-	if err := json.Unmarshal(b, &plain); err != nil {
-		return err
-	}
-	*j = ContainerVolumesElem(plain)
-	return nil
-}
-
 // The specification of a Container within the Workload.
 type Container struct {
 	// If specified, overrides the arguments passed to the container entrypoint.
@@ -263,10 +36,86 @@ type Container struct {
 	Volumes []ContainerVolumesElem `json:"volumes,omitempty" yaml:"volumes,omitempty" mapstructure:"volumes,omitempty"`
 }
 
+type ContainerFilesElem struct {
+	// The inline content for the file.
+	Content *string `json:"content,omitempty" yaml:"content,omitempty" mapstructure:"content,omitempty"`
+
+	// The optional file access mode in octal encoding. For example 0600.
+	Mode *string `json:"mode,omitempty" yaml:"mode,omitempty" mapstructure:"mode,omitempty"`
+
+	// If set to true, the placeholders expansion will not occur in the contents of
+	// the file.
+	NoExpand *bool `json:"noExpand,omitempty" yaml:"noExpand,omitempty" mapstructure:"noExpand,omitempty"`
+
+	// The relative or absolute path to the content file.
+	Source *string `json:"source,omitempty" yaml:"source,omitempty" mapstructure:"source,omitempty"`
+
+	// The file path to expose in the container.
+	Target string `json:"target" yaml:"target" mapstructure:"target"`
+}
+
+type ContainerProbe struct {
+	// HttpGet corresponds to the JSON schema field "httpGet".
+	HttpGet HttpProbe `json:"httpGet" yaml:"httpGet" mapstructure:"httpGet"`
+}
+
+// The compute resources for the container.
+type ContainerResources struct {
+	// The maximum allowed resources for the container.
+	Limits *ResourcesLimits `json:"limits,omitempty" yaml:"limits,omitempty" mapstructure:"limits,omitempty"`
+
+	// The minimal resources required for the container.
+	Requests *ResourcesLimits `json:"requests,omitempty" yaml:"requests,omitempty" mapstructure:"requests,omitempty"`
+}
+
+// The environment variables for the container.
+type ContainerVariables map[string]string
+
+type ContainerVolumesElem struct {
+	// An optional sub path in the volume.
+	Path *string `json:"path,omitempty" yaml:"path,omitempty" mapstructure:"path,omitempty"`
+
+	// Indicates if the volume should be mounted in a read-only mode.
+	ReadOnly *bool `json:"readOnly,omitempty" yaml:"readOnly,omitempty" mapstructure:"readOnly,omitempty"`
+
+	// The external volume reference.
+	Source string `json:"source" yaml:"source" mapstructure:"source"`
+
+	// The target mount on the container.
+	Target string `json:"target" yaml:"target" mapstructure:"target"`
+}
+
+// An HTTP probe details.
+type HttpProbe struct {
+	// Host name to connect to. Defaults to the workload IP. The is equivalent to a
+	// Host HTTP header.
+	Host *string `json:"host,omitempty" yaml:"host,omitempty" mapstructure:"host,omitempty"`
+
+	// Additional HTTP headers to send with the request
+	HttpHeaders []HttpProbeHttpHeadersElem `json:"httpHeaders,omitempty" yaml:"httpHeaders,omitempty" mapstructure:"httpHeaders,omitempty"`
+
+	// The path to access on the HTTP server.
+	Path string `json:"path" yaml:"path" mapstructure:"path"`
+
+	// The port to access on the workload.
+	Port int `json:"port" yaml:"port" mapstructure:"port"`
+
+	// Scheme to use for connecting to the host (HTTP or HTTPS). Defaults to HTTP.
+	Scheme *HttpProbeScheme `json:"scheme,omitempty" yaml:"scheme,omitempty" mapstructure:"scheme,omitempty"`
+}
+
+type HttpProbeHttpHeadersElem struct {
+	// The HTTP header name.
+	Name string `json:"name" yaml:"name" mapstructure:"name"`
+
+	// The HTTP header value.
+	Value string `json:"value" yaml:"value" mapstructure:"value"`
+}
+
 type HttpProbeScheme string
 
-// The metadata for the Resource.
-type ResourceMetadata map[string]interface{}
+const HttpProbeSchemeHTTP HttpProbeScheme = "HTTP"
+const HttpProbeSchemeHTTPS HttpProbeScheme = "HTTPS"
 
 // The set of Resources associated with this Workload.
 type Resource struct {
@@ -284,8 +133,188 @@ type Resource struct {
 	Type string `json:"type" yaml:"type" mapstructure:"type"`
 }
 
+// The metadata for the Resource.
+type ResourceMetadata map[string]interface{}
+
 // Optional parameters used to provision the Resource in the environment.
 type ResourceParams map[string]interface{}
+
+// UnmarshalJSON implements json.Unmarshaler.
+func (j *ServicePortProtocol) UnmarshalJSON(b []byte) error {
+	var v string
+	if err := json.Unmarshal(b, &v); err != nil {
+		return err
+	}
+	var ok bool
+	for _, expected := range enumValues_ServicePortProtocol {
+		if reflect.DeepEqual(v, expected) {
+			ok = true
+			break
+		}
+	}
+	if !ok {
+		return fmt.Errorf("invalid value (expected one of %#v): %#v", enumValues_ServicePortProtocol, v)
+	}
+	*j = ServicePortProtocol(v)
+	return nil
+}
+
+// UnmarshalJSON implements json.Unmarshaler.
+func (j *HttpProbeHttpHeadersElem) UnmarshalJSON(b []byte) error {
+	var raw map[string]interface{}
+	if err := json.Unmarshal(b, &raw); err != nil {
+		return err
+	}
+	if v, ok := raw["name"]; !ok || v == nil {
+		return fmt.Errorf("field name in HttpProbeHttpHeadersElem: required")
+	}
+	if v, ok := raw["value"]; !ok || v == nil {
+		return fmt.Errorf("field value in HttpProbeHttpHeadersElem: required")
+	}
+	type Plain HttpProbeHttpHeadersElem
+	var plain Plain
+	if err := json.Unmarshal(b, &plain); err != nil {
+		return err
+	}
+	if len(plain.Value) < 1 {
+		return fmt.Errorf("field %s length: must be >= %d", "value", 1)
+	}
+	*j = HttpProbeHttpHeadersElem(plain)
+	return nil
+}
+
+// UnmarshalJSON implements json.Unmarshaler.
+func (j *ContainerProbe) UnmarshalJSON(b []byte) error {
+	var raw map[string]interface{}
+	if err := json.Unmarshal(b, &raw); err != nil {
+		return err
+	}
+	if v, ok := raw["httpGet"]; !ok || v == nil {
+		return fmt.Errorf("field httpGet in ContainerProbe: required")
+	}
+	type Plain ContainerProbe
+	var plain Plain
+	if err := json.Unmarshal(b, &plain); err != nil {
+		return err
+	}
+	*j = ContainerProbe(plain)
+	return nil
+}
+
+// UnmarshalJSON implements json.Unmarshaler.
+func (j *ContainerVolumesElem) UnmarshalJSON(b []byte) error {
+	var raw map[string]interface{}
+	if err := json.Unmarshal(b, &raw); err != nil {
+		return err
+	}
+	if v, ok := raw["source"]; !ok || v == nil {
+		return fmt.Errorf("field source in ContainerVolumesElem: required")
+	}
+	if v, ok := raw["target"]; !ok || v == nil {
+		return fmt.Errorf("field target in ContainerVolumesElem: required")
+	}
+	type Plain ContainerVolumesElem
+	var plain Plain
+	if err := json.Unmarshal(b, &plain); err != nil {
+		return err
+	}
+	*j = ContainerVolumesElem(plain)
+	return nil
+}
+
+// UnmarshalJSON implements json.Unmarshaler.
+func (j *ContainerFilesElem) UnmarshalJSON(b []byte) error {
+	var raw map[string]interface{}
+	if err := json.Unmarshal(b, &raw); err != nil {
+		return err
+	}
+	if v, ok := raw["target"]; !ok || v == nil {
+		return fmt.Errorf("field target in ContainerFilesElem: required")
+	}
+	type Plain ContainerFilesElem
+	var plain Plain
+	if err := json.Unmarshal(b, &plain); err != nil {
+		return err
+	}
+	if plain.Source != nil && len(*plain.Source) < 1 {
+		return fmt.Errorf("field %s length: must be >= %d", "source", 1)
+	}
+	if len(plain.Target) < 1 {
+		return fmt.Errorf("field %s length: must be >= %d", "target", 1)
+	}
+	*j = ContainerFilesElem(plain)
+	return nil
+}
+
+// UnmarshalJSON implements json.Unmarshaler.
+func (j *Container) UnmarshalJSON(b []byte) error {
+	var raw map[string]interface{}
+	if err := json.Unmarshal(b, &raw); err != nil {
+		return err
+	}
+	if v, ok := raw["image"]; !ok || v == nil {
+		return fmt.Errorf("field image in Container: required")
+	}
+	type Plain Container
+	var plain Plain
+	if err := json.Unmarshal(b, &plain); err != nil {
+		return err
+	}
+	if len(plain.Image) < 1 {
+		return fmt.Errorf("field %s length: must be >= %d", "image", 1)
+	}
+	*j = Container(plain)
+	return nil
+}
+
+var enumValues_HttpProbeScheme = []interface{}{
+	"HTTP",
+	"HTTPS",
+}
+
+// UnmarshalJSON implements json.Unmarshaler.
+func (j *HttpProbe) UnmarshalJSON(b []byte) error {
+	var raw map[string]interface{}
+	if err := json.Unmarshal(b, &raw); err != nil {
+		return err
+	}
+	if v, ok := raw["path"]; !ok || v == nil {
+		return fmt.Errorf("field path in HttpProbe: required")
+	}
+	if v, ok := raw["port"]; !ok || v == nil {
+		return fmt.Errorf("field port in HttpProbe: required")
+	}
+	type Plain HttpProbe
+	var plain Plain
+	if err := json.Unmarshal(b, &plain); err != nil {
+		return err
+	}
+	if plain.Host != nil && len(*plain.Host) < 1 {
+		return fmt.Errorf("field %s length: must be >= %d", "host", 1)
+	}
+	*j = HttpProbe(plain)
+	return nil
+}
+
+// UnmarshalJSON implements json.Unmarshaler.
+func (j *HttpProbeScheme) UnmarshalJSON(b []byte) error {
+	var v string
+	if err := json.Unmarshal(b, &v); err != nil {
+		return err
+	}
+	var ok bool
+	for _, expected := range enumValues_HttpProbeScheme {
+		if reflect.DeepEqual(v, expected) {
+			ok = true
+			break
+		}
+	}
+	if !ok {
+		return fmt.Errorf("invalid value (expected one of %#v): %#v", enumValues_HttpProbeScheme, v)
+	}
+	*j = HttpProbeScheme(v)
+	return nil
+}
 
 // UnmarshalJSON implements json.Unmarshaler.
 func (j *Resource) UnmarshalJSON(b []byte) error {
@@ -317,6 +346,39 @@ func (j *Resource) UnmarshalJSON(b []byte) error {
 	return nil
 }
 
+type ServicePortProtocol string
+
+var enumValues_ServicePortProtocol = []interface{}{
+	"TCP",
+	"UDP",
+}
+
+// The compute and memory resource limits.
+type ResourcesLimits struct {
+	// The CPU limit as whole or fractional CPUs. 'm' indicates milli-CPUs. For
+	// example 2 or 125m.
+	Cpu *string `json:"cpu,omitempty" yaml:"cpu,omitempty" mapstructure:"cpu,omitempty"`
+
+	// The memory limit in bytes with optional unit specifier. For example 125M or
+	// 1Gi.
+	Memory *string `json:"memory,omitempty" yaml:"memory,omitempty" mapstructure:"memory,omitempty"`
+}
+
+const ServicePortProtocolTCP ServicePortProtocol = "TCP"
+const ServicePortProtocolUDP ServicePortProtocol = "UDP"
+
+// The network port description.
+type ServicePort struct {
+	// The public service port.
+	Port int `json:"port" yaml:"port" mapstructure:"port"`
+
+	// The transport level protocol. Defaults to TCP.
+	Protocol *ServicePortProtocol `json:"protocol,omitempty" yaml:"protocol,omitempty" mapstructure:"protocol,omitempty"`
+
+	// The internal service port. This will default to 'port' if not provided.
+	TargetPort *int `json:"targetPort,omitempty" yaml:"targetPort,omitempty" mapstructure:"targetPort,omitempty"`
+}
+
 // UnmarshalJSON implements json.Unmarshaler.
 func (j *ServicePort) UnmarshalJSON(b []byte) error {
 	var raw map[string]interface{}
@@ -335,54 +397,31 @@ func (j *ServicePort) UnmarshalJSON(b []byte) error {
 	return nil
 }
 
-// UnmarshalJSON implements json.Unmarshaler.
-func (j *ContainerFilesElem) UnmarshalJSON(b []byte) error {
-	var raw map[string]interface{}
-	if err := json.Unmarshal(b, &raw); err != nil {
-		return err
-	}
-	if v, ok := raw["target"]; !ok || v == nil {
-		return fmt.Errorf("field target in ContainerFilesElem: required")
-	}
-	type Plain ContainerFilesElem
-	var plain Plain
-	if err := json.Unmarshal(b, &plain); err != nil {
-		return err
-	}
-	if plain.Source != nil && len(*plain.Source) < 1 {
-		return fmt.Errorf("field %s length: must be >= %d", "source", 1)
-	}
-	if len(plain.Target) < 1 {
-		return fmt.Errorf("field %s length: must be >= %d", "target", 1)
-	}
-	*j = ContainerFilesElem(plain)
-	return nil
+// The declared Score Specification version. The container name must be a valid
+// RFC1123 Label Name of up to 63 characters, including a-z, 0-9, '-' but may not
+// start or end with '-'.
+type WorkloadContainers map[string]Container
+
+// The metadata description of the Workload.
+type WorkloadMetadata map[string]interface{}
+
+// The Resource dependencies needed by the Workload. The resource name must be a
+// valid RFC1123 Label Name of up to 63 characters, including a-z, 0-9, '-' but may
+// not start or end with '-'.
+type WorkloadResources map[string]Resource
+
+// The set of named network ports published by the service. The service name must
+// be a valid RFC1123 Label Name of up to 63 characters, including a-z, 0-9, '-'
+// but may not start or end with '-'.
+type WorkloadServicePorts map[string]ServicePort
+
+// The service that the workload provides.
+type WorkloadService struct {
+	// The set of named network ports published by the service. The service name must
+	// be a valid RFC1123 Label Name of up to 63 characters, including a-z, 0-9, '-'
+	// but may not start or end with '-'.
+	Ports WorkloadServicePorts `json:"ports,omitempty" yaml:"ports,omitempty" mapstructure:"ports,omitempty"`
 }
-
-// UnmarshalJSON implements json.Unmarshaler.
-func (j *ServicePortProtocol) UnmarshalJSON(b []byte) error {
-	var v string
-	if err := json.Unmarshal(b, &v); err != nil {
-		return err
-	}
-	var ok bool
-	for _, expected := range enumValues_ServicePortProtocol {
-		if reflect.DeepEqual(v, expected) {
-			ok = true
-			break
-		}
-	}
-	if !ok {
-		return fmt.Errorf("invalid value (expected one of %#v): %#v", enumValues_ServicePortProtocol, v)
-	}
-	*j = ServicePortProtocol(v)
-	return nil
-}
-
-type ServicePortProtocol string
-
-const ServicePortProtocolTCP ServicePortProtocol = "TCP"
-const ServicePortProtocolUDP ServicePortProtocol = "UDP"
 
 // Score workload specification
 type Workload struct {
@@ -406,37 +445,26 @@ type Workload struct {
 	Service *WorkloadService `json:"service,omitempty" yaml:"service,omitempty" mapstructure:"service,omitempty"`
 }
 
-// The declared Score Specification version. The container name must be a valid
-// RFC1123 Label Name of up to 63 characters, including a-z, 0-9, '-' but may not
-// start or end with '-'.
-type WorkloadContainers map[string]Container
-
-// The metadata description of the Workload.
-type WorkloadMetadata map[string]interface{}
-
-// The Resource dependencies needed by the Workload. The resource name must be a
-// valid RFC1123 Label Name of up to 63 characters, including a-z, 0-9, '-' but may
-// not start or end with '-'.
-type WorkloadResources map[string]Resource
-
-// The service that the workload provides.
-type WorkloadService struct {
-	// The set of named network ports published by the service. The service name must
-	// be a valid RFC1123 Label Name of up to 63 characters, including a-z, 0-9, '-'
-	// but may not start or end with '-'.
-	Ports WorkloadServicePorts `json:"ports,omitempty" yaml:"ports,omitempty" mapstructure:"ports,omitempty"`
-}
-
-// The set of named network ports published by the service. The service name must
-// be a valid RFC1123 Label Name of up to 63 characters, including a-z, 0-9, '-'
-// but may not start or end with '-'.
-type WorkloadServicePorts map[string]ServicePort
-
-var enumValues_HttpProbeScheme = []interface{}{
-	"HTTP",
-	"HTTPS",
-}
-var enumValues_ServicePortProtocol = []interface{}{
-	"TCP",
-	"UDP",
+// UnmarshalJSON implements json.Unmarshaler.
+func (j *Workload) UnmarshalJSON(b []byte) error {
+	var raw map[string]interface{}
+	if err := json.Unmarshal(b, &raw); err != nil {
+		return err
+	}
+	if v, ok := raw["apiVersion"]; !ok || v == nil {
+		return fmt.Errorf("field apiVersion in Workload: required")
+	}
+	if v, ok := raw["containers"]; !ok || v == nil {
+		return fmt.Errorf("field containers in Workload: required")
+	}
+	if v, ok := raw["metadata"]; !ok || v == nil {
+		return fmt.Errorf("field metadata in Workload: required")
+	}
+	type Plain Workload
+	var plain Plain
+	if err := json.Unmarshal(b, &plain); err != nil {
+		return err
+	}
+	*j = Workload(plain)
+	return nil
 }


### PR DESCRIPTION
Latest score schema improves the requirements on the http probe headers. This is low priority but worth updating to in score-go too for any implementations that can pick this up soon.

No breaking changes to customers unless they have deliberately misconfigured http headers on a liveness probe.