### PR TITLE
chore: updated 'schema/files/' changes from 136e984..64fee38

### DIFF
--- a/schema/files/README.md
+++ b/schema/files/README.md
@@ -1,7 +1,7 @@
 # JSON schemas for Score files
 
-| version  | file            |
-|----------|-----------------|
+| version | file |
+| --- | --- |
 | v1-beta1 | score-v1b1.json |
 
 ## Embed schemas into project

--- a/schema/files/samples/score-full.yaml
+++ b/schema/files/samples/score-full.yaml
@@ -2,6 +2,8 @@ apiVersion: score.dev/v1b1
 metadata:
   name: example-workload-name123
   extra-key: extra-value
+  annotations:
+    prefix.com/Another-Key_Annotation.2: something else
 service:
   ports:
     port-one:

--- a/schema/files/score-v1b1.json
+++ b/schema/files/score-v1b1.json
@@ -30,6 +30,18 @@
           "minLength": 2,
           "maxLength": 63,
           "pattern": "^[a-z0-9][a-z0-9-]{0,61}[a-z0-9]$"
+        },
+        "annotations": {
+          "description": "Annotations that apply to the Workload. The annotation can contain A-Z, a-z, 0-9, and '-' and may contain an optional /-separated RFC1123 Host Name prefix.",
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "propertyNames": {
+            "minLength": 2,
+            "maxLength": 316,
+            "pattern": "^(([a-z0-9][a-z0-9-]{0,61}[a-z0-9])(\\.[a-z0-9][a-z0-9-]{0,61}[a-z0-9])*/)?[A-Za-z0-9][A-Za-z0-9._-]{0,61}[A-Za-z0-9]$"
+          }
         }
       }
     },


### PR DESCRIPTION
64fee38 feat: added specification of workload.metadata.annotations (#17)

git-subtree-dir: schema/files
git-subtree-split: 64fee38c5326c54afc76d089aab8470e0bfce303
