### PR TITLE
chore: correct licensing headers of existing files

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,3 +17,8 @@ jobs:
       - run: |
           go vet ./...
           go test ./... --cover
+
+      - name: Install license check tool
+        run: go install github.com/google/addlicense@latest
+      - name: Check licenses
+        run: addlicense -l apache -check -v -ignore '**/*.yaml' -c Humanitec ./loader ./schema ./types ./pkg

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,6 +33,18 @@ Never made an open-source contribution before? Wondering how contributions work 
 13. Introduce changes to the pull request if the reviewing maintainer recommends them.
 14. Celebrate your success after your pull request is merged!
 
+### Ensuring all source files contain a license header
+
+A [LICENSE](LICENSE), and [NOTICE](NOTICE) file exists in the root directory, and each source code file should contain
+an appropriate Apache 2 header.
+
+To check and update all files, run:
+
+```
+$ go install github.com/google/addlicense@latest
+$ addlicense -l apache -v -ignore '**/*.yaml' -c Humanitec ./loader ./schema ./types ./pkg
+```
+
 ## Feature requests
 
 ## Code reviews

--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,5 @@
+Apache Score
+Copyright [2022-2024] The Apache Software Foundation
+
+This product includes software developed at
+The Apache Software Foundation (/).

--- a/loader/loader.go
+++ b/loader/loader.go
@@ -1,10 +1,17 @@
-/*
-Apache Score
-Copyright 2020 The Apache Software Foundation
+// Copyright 2020 Humanitec
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
-This product includes software developed at
-The Apache Software Foundation (http://www.apache.org/).
-*/
 package loader
 
 import (

--- a/loader/loader_test.go
+++ b/loader/loader_test.go
@@ -1,10 +1,17 @@
-/*
-Apache Score
-Copyright 2020 The Apache Software Foundation
+// Copyright 2020 Humanitec
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
-This product includes software developed at
-The Apache Software Foundation (http://www.apache.org/).
-*/
 package loader
 
 import (

--- a/loader/normalize.go
+++ b/loader/normalize.go
@@ -1,3 +1,17 @@
+// Copyright 2024 Humanitec
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package loader
 
 import (

--- a/loader/normalize_test.go
+++ b/loader/normalize_test.go
@@ -1,3 +1,17 @@
+// Copyright 2024 Humanitec
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package loader
 
 import (

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -1,10 +1,17 @@
-/*
-Apache Score
-Copyright 2020 The Apache Software Foundation
+// Copyright 2020 Humanitec
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
-This product includes software developed at
-The Apache Software Foundation (http://www.apache.org/).
-*/
 package schema
 
 import _ "embed"

--- a/schema/schema_test.go
+++ b/schema/schema_test.go
@@ -1,10 +1,17 @@
-/*
-Apache Score
-Copyright 2020 The Apache Software Foundation
+// Copyright 2020 Humanitec
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
-This product includes software developed at
-The Apache Software Foundation (http://www.apache.org/).
-*/
 package schema
 
 import (

--- a/schema/validate.go
+++ b/schema/validate.go
@@ -1,10 +1,17 @@
-/*
-Apache Score
-Copyright 2020 The Apache Software Foundation
+// Copyright 2020 Humanitec
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
-This product includes software developed at
-The Apache Software Foundation (http://www.apache.org/).
-*/
 package schema
 
 import (

--- a/schema/validate_test.go
+++ b/schema/validate_test.go
@@ -1,10 +1,17 @@
-/*
-Apache Score
-Copyright 2020 The Apache Software Foundation
+// Copyright 2020 Humanitec
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
-This product includes software developed at
-The Apache Software Foundation (http://www.apache.org/).
-*/
 package schema
 
 import (

--- a/types/types.go
+++ b/types/types.go
@@ -1,3 +1,17 @@
+// Copyright 2024 Humanitec
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package types
 
 //go:generate go run github.com/atombender/go-jsonschema@v0.15.0 -v --schema-output=https://score.dev/schemas/score=types.gen.go --schema-package=https://score.dev/schemas/score=types --schema-root-type=https://score.dev/schemas/score=Workload ../schema/files/score-v1b1.json.modified


### PR DESCRIPTION
Similar to the same change in score-compose: https://github.com/score-spec/score-compose/pull/81. This corrects the source code licensing headers and ensures the notice file exists.
