### PR TITLE
fix: remove deprecated 0-keys placeholder behavior

### DIFF
--- a/framework/resource_uid.go
+++ b/framework/resource_uid.go
@@ -34,14 +34,17 @@ func NewResourceUid(workloadName string, resName string, resType string, resClas
 	return ResourceUid(fmt.Sprintf("%s.%s#%s.%s", resType, *resClass, workloadName, resName))
 }
 
+// Type returns the type of the resource
 func (r ResourceUid) Type() string {
 	return string(r)[0:strings.Index(string(r), ".")]
 }
 
+// Class returns the class of the resource, defaulted to "default"
 func (r ResourceUid) Class() string {
 	return string(r)[strings.Index(string(r), ".")+1 : strings.Index(string(r), "#")]
 }
 
+// Id returns the id of the resource, either <workload>.<name> or <id> if id is specified
 func (r ResourceUid) Id() string {
 	return string(r)[strings.Index(string(r), "#")+1:]
 }

--- a/framework/state.go
+++ b/framework/state.go
@@ -54,7 +54,7 @@ type ScoreResourceState struct {
 	Type string `yaml:"type"`
 	// Class is the resource class or 'default' if not provided.
 	Class string `yaml:"class"`
-	// Id is the generated id for the resource, either <workload>.<resName> or <shared>.<id>. This is tracked so that
+	// Id is the generated id for the resource, either <workload>.<resName> or <id>. This is tracked so that
 	// we can deduplicate and work out where a resource came from.
 	Id string `yaml:"id"`
 

--- a/framework/substitution.go
+++ b/framework/substitution.go
@@ -136,9 +136,6 @@ func BuildSubstitutionFunction(metadata map[string]interface{}, resources map[st
 			rv, ok := resources[parts[1]]
 			if !ok {
 				return "", fmt.Errorf("invalid ref '%s': no known resource '%s'", ref, parts[1])
-			} else if len(parts) == 2 {
-				// TODO: deprecate this - this is an annoying and nonsensical legacy thing
-				return parts[1], nil
 			} else if rv2, err := rv(parts[2:]...); err != nil {
 				return "", fmt.Errorf("invalid ref '%s': %w", ref, err)
 			} else {

--- a/framework/substitution_test.go
+++ b/framework/substitution_test.go
@@ -35,18 +35,27 @@ func init() {
 		},
 	}, map[string]OutputLookupFunc{
 		"env": func(keys ...string) (interface{}, error) {
-			if len(keys) != 1 {
+			if len(keys) == 0 {
+				return "env", nil
+			} else if len(keys) != 1 {
 				return nil, fmt.Errorf("fail")
 			}
 			return "${" + keys[0] + "}", nil
 		},
 		"db": func(keys ...string) (interface{}, error) {
-			if len(keys) < 1 {
+			if len(keys) == 0 {
+				return "db", nil
+			} else if len(keys) < 1 {
 				return nil, fmt.Errorf("fail")
 			}
 			return "${DB_" + strings.ToUpper(strings.Join(keys, "_")) + "?required}", nil
 		},
-		"static": mapLookupOutput(map[string]interface{}{"x": "a"}),
+		"static": func(keys ...string) (interface{}, error) {
+			if len(keys) == 0 {
+				return "static", nil
+			}
+			return mapLookupOutput(map[string]interface{}{"x": "a"})(keys...)
+		},
 	})
 }
 


### PR DESCRIPTION
There was some behavior inherited from an older version of score-compose that resolved 2 part placeholders like `${resources.<name>}` to `<name>`. This was used as a mechanism to refer to certain resources in some contexts (like volumes). A similar mechanism exists in some parts of Humanitec's implementation.

This funcitonality was ported over to score-go, but can now be removed and any special behavior can be moved into the implementations respectively. 

As an aside this PR also fixes some comments in other places that were incorrect.

This is what the score-compose PR would look like: https://github.com/score-spec/score-compose/pull/103