### PR TITLE
fix(framework): fixed param/meta comparison for duplicate resource def with the same id

### DIFF
--- a/framework/state.go
+++ b/framework/state.go
@@ -133,14 +133,14 @@ func (s *State[StateExtras, WorkloadExtras]) WithPrimedResources() (*State[State
 			} else {
 				// multiple definitions of the same shared resource, let's check for conflicting params and metadata
 				if res.Params != nil {
-					if existing.Params != nil && !reflect.DeepEqual(existing.Params, res.Params) {
+					if existing.Params != nil && !reflect.DeepEqual(existing.Params, map[string]interface{}(res.Params)) {
 						return nil, fmt.Errorf("resource '%s': multiple definitions with different params", resUid)
 					}
 					existing.Params = res.Params
 					existing.SourceWorkload = workloadName
 				}
 				if res.Metadata != nil {
-					if existing.Metadata != nil && !reflect.DeepEqual(existing.Metadata, res.Metadata) {
+					if existing.Metadata != nil && !reflect.DeepEqual(existing.Metadata, map[string]interface{}(res.Metadata)) {
 						return nil, fmt.Errorf("resource '%s': multiple definitions with different metadata", resUid)
 					}
 					existing.Metadata = res.Metadata

--- a/framework/state_test.go
+++ b/framework/state_test.go
@@ -156,7 +156,27 @@ resources:
 		}, next.Resources)
 	})
 
-	t.Run("one workload - diff metadata", func(t *testing.T) {
+	t.Run("one workload - same resource - same metadata", func(t *testing.T) {
+		next := mustAddWorkload(t, start, `
+metadata: {"name": "example"}
+resources:
+  one:
+    type: thing
+    id: elephant
+    metadata:
+      x: a
+  two:
+    type: thing
+    id: elephant
+    metadata:
+      x: a
+`)
+		next, err := next.WithPrimedResources()
+		assert.NoError(t, err)
+		assert.Len(t, next.Resources, 1)
+	})
+
+	t.Run("one workload - same resource - diff metadata", func(t *testing.T) {
 		next := mustAddWorkload(t, start, `
 metadata: {"name": "example"}
 resources:


### PR DESCRIPTION
While upgrading a Score implementation at Humanitec I found a bug when processing a spec like the following (which was used in an existing unit test):

```
...
resources:
  thing-a:
    type: cat
    id: garfield
    params:
      color: orange
  thing-b:
    type: cat
    id: garfield
    params:
      color: orange 
```

This is an esoteric example which makes more sense when looking at multiple score workloads that define the same resource in the same project. The current main branch check was failing because deep-equal returned false because the metadata dictionaries were technically not the same outer type at the time of comparison.

The fix is just coercing it to the comparable type `map[string]interface{}`.

Specs like this (params or metadata defined only once) will still work fine without errors.

```
  thing-a:
    type: cat
    id: garfield
    params:
      color: orange
  thing-b:
    type: cat
    id: garfield
```
