### PR TITLE
fix: allow resource outputs to be persisted

### DIFF
--- a/framework/state.go
+++ b/framework/state.go
@@ -70,9 +70,9 @@ type ScoreResourceState struct {
 	// State is the internal state local to this resource. It will be persisted to disk when possible.
 	State map[string]interface{} `yaml:"state"`
 
-	// Outputs is the current set of outputs for the resource. This is the output of calling the provider. It doesn't
-	// get persisted to disk.
-	Outputs map[string]interface{} `yaml:"-"`
+	// Outputs is the current set of outputs for the resource. This is the output of calling the provider. It may contain
+	// secrets so be careful when persisting this to disk.
+	Outputs map[string]interface{} `yaml:"outputs,omitempty"`
 	// OutputLookupFunc is function that allows certain in-process providers to defer any output generation. If this is
 	// not provided, it will fall back to using what's in the outputs.
 	OutputLookupFunc OutputLookupFunc `yaml:"-"`
@@ -122,6 +122,7 @@ func (s *State[StateExtras, WorkloadExtras]) WithPrimedResources() (*State[State
 					Params:         res.Params,
 					SourceWorkload: workloadName,
 					State:          map[string]interface{}{},
+					Outputs:        map[string]interface{}{},
 				}
 				primedResourceUids[resUid] = true
 			} else if !primedResourceUids[resUid] {

--- a/framework/state_test.go
+++ b/framework/state_test.go
@@ -134,11 +134,11 @@ resources:
 		assert.Len(t, start.Resources, 0)
 		assert.Equal(t, map[ResourceUid]ScoreResourceState{
 			"thing.default#example.one": {
-				Type: "thing", Class: "default", Id: "example.one", State: map[string]interface{}{},
+				Type: "thing", Class: "default", Id: "example.one", State: map[string]interface{}{}, Outputs: map[string]interface{}{},
 				SourceWorkload: "example",
 			},
 			"thing2.banana#example.two": {
-				Type: "thing2", Class: "banana", Id: "example.two", State: map[string]interface{}{},
+				Type: "thing2", Class: "banana", Id: "example.two", State: map[string]interface{}{}, Outputs: map[string]interface{}{},
 				SourceWorkload: "example",
 			},
 			"thing3.apple#dog": {
@@ -146,12 +146,14 @@ resources:
 				Metadata:       map[string]interface{}{"annotations": score.ResourceMetadata{"foo": "bar"}},
 				Params:         map[string]interface{}{"color": "green"},
 				SourceWorkload: "example",
+				Outputs:        map[string]interface{}{},
 			},
 			"thing4.default#elephant": {
 				Type: "thing4", Class: "default", Id: "elephant", State: map[string]interface{}{},
 				Metadata:       map[string]interface{}{"x": "y"},
 				Params:         map[string]interface{}{"color": "blue"},
 				SourceWorkload: "example",
+				Outputs:        map[string]interface{}{},
 			},
 		}, next.Resources)
 	})
@@ -244,14 +246,17 @@ resources:
 				"thing.default#example1.one": {
 					Type: "thing", Class: "default", Id: "example1.one", State: map[string]interface{}{},
 					SourceWorkload: "example1",
+					Outputs:        map[string]interface{}{},
 				},
 				"thing.default#example2.one": {
 					Type: "thing", Class: "default", Id: "example2.one", State: map[string]interface{}{},
 					SourceWorkload: "example2",
+					Outputs:        map[string]interface{}{},
 				},
 				"thing2.default#dog": {
 					Type: "thing2", Class: "default", Id: "dog", State: map[string]interface{}{},
 					SourceWorkload: "example1",
+					Outputs:        map[string]interface{}{},
 				},
 			}, next.Resources)
 		})


### PR DESCRIPTION
Small change to allow outputs to be persisted in the state file. This supports https://github.com/score-spec/score-compose/issues/115