### PR TITLE
fix(types): universal improvement to metadata decoding

### DIFF
--- a/framework/state.go
+++ b/framework/state.go
@@ -97,12 +97,6 @@ func (s *State[StateExtras, WorkloadExtras, ResourceExtras]) WithWorkload(spec *
 		out.Workloads = maps.Clone(s.Workloads)
 	}
 
-	spec.Metadata = coerceAnnotationsType(spec.Metadata)
-	for resName, resource := range spec.Resources {
-		resource.Metadata = coerceAnnotationsType(resource.Metadata)
-		spec.Resources[resName] = resource
-	}
-
 	name, ok := spec.Metadata["name"].(string)
 	if !ok {
 		return nil, fmt.Errorf("metadata: name: is missing or is not a string")
@@ -180,19 +174,6 @@ func (s *State[StateExtras, WorkloadExtras, ResourceExtras]) WithPrimedResources
 		}
 	}
 	return &out, nil
-}
-
-// The metadata maps (workload metadata and resource metadata) decode in a weird way in yaml.v3 which causes type
-// coercions elsewhere in the software to fail. We have to rewrite the type to be clear.
-func coerceAnnotationsType(in map[string]interface{}) map[string]interface{} {
-	if a, ok := in["annotations"].(score.WorkloadMetadata); ok {
-		in = maps.Clone(in)
-		in["annotations"] = map[string]interface{}(a)
-	} else if a, ok := in["annotations"].(score.ResourceMetadata); ok {
-		in = maps.Clone(in)
-		in["annotations"] = map[string]interface{}(a)
-	}
-	return in
 }
 
 func (s *State[StateExtras, WorkloadExtras, ResourceExtras]) getResourceDependencies(workloadName, resName string) (map[ResourceUid]bool, error) {

--- a/types/types.go
+++ b/types/types.go
@@ -15,3 +15,21 @@
 package types
 
 //go:generate go run github.com/atombender/go-jsonschema@v0.15.0 -v --schema-output=https://score.dev/schemas/score=types.gen.go --schema-package=https://score.dev/schemas/score=types --schema-root-type=https://score.dev/schemas/score=Workload ../schema/files/score-v1b1.json.modified
+
+func (m *ResourceMetadata) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	var out map[string]interface{}
+	if err := unmarshal(&out); err != nil {
+		return err
+	}
+	*m = ResourceMetadata(out)
+	return nil
+}
+
+func (m *WorkloadMetadata) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	var out map[string]interface{}
+	if err := unmarshal(&out); err != nil {
+		return err
+	}
+	*m = WorkloadMetadata(out)
+	return nil
+}


### PR DESCRIPTION
This is a follow on from #39, but moves the support into the yaml decoding layer to reduce impact to other score implementations.
