### PR TITLE
fix: field description in the containers section

### DIFF
--- a/schema/files/score-v1b1.json
+++ b/schema/files/score-v1b1.json
@@ -65,7 +65,7 @@
       }
     },
     "containers": {
-      "description": "The declared Score Specification version. The container name must be a valid RFC1123 Label Name of up to 63 characters, including a-z, 0-9, '-' but may not start or end with '-'.",
+      "description": "The set of named containers in the Workload. The container name must be a valid RFC1123 Label Name of up to 63 characters, including a-z, 0-9, '-' but may not start or end with '-'.",
       "type": "object",
       "minProperties": 1,
       "additionalProperties": {


### PR DESCRIPTION
I've noticed that the containers section had an incorrect description. This PR should fix it. This shouldn't need to picked up in score-go, since the descriptions aren't used as such there.