### PR TITLE
Update ci.yml - explicit contents read permission

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,27 +1,24 @@
 name: CI
-
 on:
   # We run the CI checks on any pull request updates or pushes to the main branch after PR merge.
   pull_request:
   push:
     branches:
       - main
-
+permissions:
+  contents: read
 jobs:
   ci:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-
       - uses: actions/setup-go@v5
         with:
           go-version-file: 'go.mod'
           check-latest: true
-
       - run: |
           go vet ./...
           go test ./... --cover
-
       - name: Install license check tool
         run: go install github.com/google/addlicense@latest
       - name: Check licenses


### PR DESCRIPTION
Token-Permissions OpenSSF Scorecard check

> Reason: detected GitHub workflow tokens with excessive permissions
```
Warn: no topLevel permission defined: .github/workflows/ci.yml:1: Visit https://app.stepsecurity.io/secureworkflow/score-spec/score-go/ci.yml/main?enable=permissions
Tick the 'Restrict permissions for GITHUB_TOKEN'
Untick other options
```