### PR TITLE
Update go.mod - 1.23.4

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,6 @@
 module github.com/score-spec/score-go
 
-go 1.23
-
-toolchain go1.23.0
+go 1.23.4
 
 require (
 	github.com/mitchellh/mapstructure v1.5.0


### PR DESCRIPTION
- In `go.mod`: `1.23` --> `1.23.4`

For reproducible build/release based on a specific Go version.

Note: we could have the digest for the base image in the `Dockerfile`, but not going that path for now.