### PR TITLE
fix: allow binary file contents

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,17 +6,17 @@ toolchain go1.23.0
 
 require (
 	github.com/mitchellh/mapstructure v1.5.0
+	github.com/opencontainers/image-spec v1.1.0
 	github.com/santhosh-tekuri/jsonschema/v5 v5.3.1
 	github.com/stretchr/testify v1.9.0
+	golang.org/x/text v0.21.0
 	gopkg.in/yaml.v3 v3.0.1
+	oras.land/oras-go/v2 v2.5.0
 )
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/opencontainers/go-digest v1.0.0 // indirect
-	github.com/opencontainers/image-spec v1.1.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	golang.org/x/sync v0.10.0 // indirect
-	golang.org/x/text v0.21.0 // indirect
-	oras.land/oras-go/v2 v2.5.0 // indirect
 )

--- a/go.mod
+++ b/go.mod
@@ -16,6 +16,7 @@ require (
 	github.com/opencontainers/go-digest v1.0.0 // indirect
 	github.com/opencontainers/image-spec v1.1.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	golang.org/x/sync v0.6.0 // indirect
+	golang.org/x/sync v0.10.0 // indirect
+	golang.org/x/text v0.21.0 // indirect
 	oras.land/oras-go/v2 v2.5.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -14,6 +14,10 @@ github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsT
 github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 golang.org/x/sync v0.6.0 h1:5BMeUDZ7vkXGfEr1x9B4bRcTH4lpkTkpdh0T/J+qjbQ=
 golang.org/x/sync v0.6.0/go.mod h1:Czt+wKu1gCyEFDUtn0jG5QVvpJ6rzVqr5aXyt9drQfk=
+golang.org/x/sync v0.10.0 h1:3NQrjDixjgGwUOCaF8w2+VYHv0Ve/vGYSbdkTa98gmQ=
+golang.org/x/sync v0.10.0/go.mod h1:Czt+wKu1gCyEFDUtn0jG5QVvpJ6rzVqr5aXyt9drQfk=
+golang.org/x/text v0.21.0 h1:zyQAAkrwaneQ066sspRyJaG9VNi/YJ1NfzcGB3hZ/qo=
+golang.org/x/text v0.21.0/go.mod h1:4IBbMaMmOPCJ8SecivzSH54+73PCFmPWxNTLm+vZkEQ=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=

--- a/go.sum
+++ b/go.sum
@@ -12,8 +12,6 @@ github.com/santhosh-tekuri/jsonschema/v5 v5.3.1 h1:lZUw3E0/J3roVtGQ+SCrUrg3ON6Ng
 github.com/santhosh-tekuri/jsonschema/v5 v5.3.1/go.mod h1:uToXkOrWAZ6/Oc07xWQrPOhJotwFIyu2bBVN41fcDUY=
 github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsTg=
 github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
-golang.org/x/sync v0.6.0 h1:5BMeUDZ7vkXGfEr1x9B4bRcTH4lpkTkpdh0T/J+qjbQ=
-golang.org/x/sync v0.6.0/go.mod h1:Czt+wKu1gCyEFDUtn0jG5QVvpJ6rzVqr5aXyt9drQfk=
 golang.org/x/sync v0.10.0 h1:3NQrjDixjgGwUOCaF8w2+VYHv0Ve/vGYSbdkTa98gmQ=
 golang.org/x/sync v0.10.0/go.mod h1:Czt+wKu1gCyEFDUtn0jG5QVvpJ6rzVqr5aXyt9drQfk=
 golang.org/x/text v0.21.0 h1:zyQAAkrwaneQ066sspRyJaG9VNi/YJ1NfzcGB3hZ/qo=

--- a/loader/normalize.go
+++ b/loader/normalize.go
@@ -18,6 +18,9 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"unicode/utf8"
+
+	"golang.org/x/text/encoding/charmap"
 
 	"github.com/score-spec/score-go/types"
 )
@@ -51,6 +54,13 @@ func readFile(baseDir, path string) (string, error) {
 	raw, err := os.ReadFile(path)
 	if err != nil {
 		return "", err
+	}
+
+	if !utf8.Valid(raw) {
+		raw, err = charmap.ISO8859_1.NewDecoder().Bytes(raw)
+		if err != nil {
+			return "", fmt.Errorf("failed to convert raw input bytes into utf-8")
+		}
 	}
 
 	return string(raw), nil

--- a/loader/normalize_test.go
+++ b/loader/normalize_test.go
@@ -15,12 +15,16 @@
 package loader
 
 import (
+	"encoding/json"
 	"errors"
 	"io"
+	"os"
+	"path/filepath"
 	"testing"
 
-	"github.com/score-spec/score-go/types"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/score-spec/score-go/types"
 )
 
 func TestNormalize(t *testing.T) {
@@ -105,4 +109,34 @@ func TestNormalize(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestNormalizeBinaryFile(t *testing.T) {
+	td := t.TempDir()
+	assert.NoError(t, os.WriteFile(filepath.Join(td, "binary"), []byte{0x30, 0x82, 0x03, 0x6b, 0x30}, 0644))
+	wkld := &types.Workload{
+		ApiVersion: "score.dev/v1b1",
+		Metadata: types.WorkloadMetadata{
+			"name": "hello-world",
+		},
+		Containers: types.WorkloadContainers{
+			"hello": types.Container{
+				Files: []types.ContainerFilesElem{
+					{
+						Source: stringRef("./binary"),
+						Target: "/binary",
+					},
+				},
+			},
+		},
+	}
+
+	assert.NoError(t, Normalize(wkld, td))
+	assert.Equal(t, "0\u0082\x03k0", *wkld.Containers["hello"].Files[0].Content)
+	raw, _ := json.Marshal(wkld)
+	assert.Equal(t, "{\"apiVersion\":\"score.dev/v1b1\",\"containers\":{\"hello\":{\"files\":[{\"content\":\"0\u0082\\u0003k0\",\"target\":\"/binary\"}],\"image\":\"\"}},\"metadata\":{\"name\":\"hello-world\"}}", string(raw))
+
+	var s map[string]interface{}
+	assert.NoError(t, json.Unmarshal(raw, &s))
+	assert.Equal(t, "0\u0082\x03k0", s["containers"].(map[string]interface{})["hello"].(map[string]interface{})["files"].([]interface{})[0].(map[string]interface{})["content"])
 }


### PR DESCRIPTION
I was tracking down an issue that occurred when mounting a binary file like a targz or certificate into a Score workload:

```
$ openssl req -x509 -newkey rsa:2048 -keyout key.pem -out cert.pem -sha256 -days 365
$ openssl x509 -in cert.pem -out cert.der -outform der
$ cat score.yaml
apiVersion: score.dev/v1b1
metadata:
  name: example
containers:
  main:
    image: debian
    args:
    - sleep
    - infinity
    files:
    - target: /mnt/cert.der
      source: ./cert.der
```

When deploying this, I found that lots of the bytes in the file were replaced with \ufffd or \xEF\xBF\xBD, the invalid-unicode replacement bytes! This is because the binary file being mounted is not valid utf-8.

To fix this, we need to try to detect the invalid utf-8 and read in the file in a more literal character set like ISO-8859-1 and convert this to utf-8 using the x/text/encoding package.

This seems to work as expected via unit test and we can upgrade the various score implementations to better support this now :)