### PR TITLE
chore: update go to 1.23.5

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/score-spec/score-go
 
-go 1.23.4
+go 1.23.5
 
 require (
 	github.com/mitchellh/mapstructure v1.5.0


### PR DESCRIPTION
chore: update go to 1.23.5

For some reasons, Dependabot is not picking this up...
https://github.com/score-spec/score-go/blob/main/.github/dependabot.yml#L11