### PR TITLE
GetStdinFile functionality moved

### DIFF
--- a/uriget/uriget.go
+++ b/uriget/uriget.go
@@ -23,6 +23,21 @@ import (
 	"oras.land/oras-go/v2/registry/remote"
 )
 
+func GetStdinFile(ctx context.Context) ([]byte, error) {
+	// Check if stdin is being piped
+	stat, err := os.Stdin.Stat()
+	if err != nil {
+		return nil, err
+	}
+
+	// Check if stdin is a pipe
+	if (stat.Mode() & os.ModeCharDevice) == 0 {
+		return io.ReadAll(os.Stdin)
+	}
+
+	return nil, fmt.Errorf("no stdin data provided")
+}
+
 // options is a struct holding fields that may need to have overrides in certain environments or during unit testing.
 // The options struct can be modified by using Option functions. See defaultOptions.
 type options struct {


### PR DESCRIPTION


### **Description**
This pull request moves the `GetStdinFile` function from the score-compose repository to the score-go repository under the uriget package.

### **Changes Made**
Moved `GetStdinFile` to score-go:

- The `GetStdinFile` function is now located in score-go/uriget/uriget.go.

- This function reads from stdin and returns the content.

Updated score-compose to Use score-go:

- The score-compose repository now imports and uses the `GetStdinFile` function from the score-go repository.

- Updated the necessary import paths and function calls in score-compose/internal/command/init.go.



