### PR TITLE
feat: add formatter output library

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,7 +42,7 @@ To check and update all files, run:
 
 ```
 $ go install github.com/google/addlicense@latest
-$ addlicense -l apache -v -ignore '**/*.yaml' -c Humanitec ./loader ./schema ./types ./pkg
+$ addlicense -l apache -v -ignore '**/*.yaml' -c Humanitec ./loader ./schema ./types ./formatter
 ```
 
 ## Feature requests

--- a/formatter/output.go
+++ b/formatter/output.go
@@ -1,0 +1,87 @@
+// Copyright 2025 Humanitec
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package formatter
+
+import (
+	"encoding/json"
+	"io"
+	"os"
+
+	"github.com/olekukonko/tablewriter"
+	"gopkg.in/yaml.v3"
+)
+
+type OutputFormatter interface {
+	Display() error
+}
+
+type JSONOutputFormatter[T any] struct {
+	Data T
+	Out  io.Writer
+}
+
+type YAMLOutputFormatter[T any] struct {
+	Data T
+	Out  io.Writer
+}
+
+type TableOutputFormatter struct {
+	Headers []string
+	Rows    [][]string
+	Out     io.Writer
+}
+
+func (t *TableOutputFormatter) Display() error {
+	// Default to stdout if no output is provided
+	if t.Out == nil {
+		t.Out = os.Stdout
+	}
+	table := tablewriter.NewWriter(t.Out)
+	table.SetHeader(t.Headers)
+	table.AppendBulk(t.Rows)
+	table.SetAutoWrapText(false)
+	table.SetRowLine(true)
+	table.SetCenterSeparator("+")
+	table.SetColumnSeparator("|")
+	table.SetRowSeparator("-")
+	table.Render()
+	return nil
+}
+
+func (j *JSONOutputFormatter[T]) Display() error {
+	// Default to stdout if no output is provided
+	if j.Out == nil {
+		j.Out = os.Stdout
+	}
+	encoder := json.NewEncoder(j.Out)
+	encoder.SetIndent("", "  ")
+	if err := encoder.Encode(j.Data); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (y *YAMLOutputFormatter[T]) Display() error {
+	// Default to stdout if no output is provided
+	if y.Out == nil {
+		y.Out = os.Stdout
+	}
+
+	encoder := yaml.NewEncoder(y.Out)
+	if err := encoder.Encode(y.Data); err != nil {
+		return err
+	}
+	return nil
+}

--- a/formatter/output_test.go
+++ b/formatter/output_test.go
@@ -1,0 +1,113 @@
+// Copyright 2024 Humanitec
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package formatter
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestTableOutputFormatter_Display(t *testing.T) {
+	tests := []struct {
+		name    string
+		headers []string
+		rows    [][]string
+		want    string
+	}{
+		{
+			name:    "simple table",
+			headers: []string{"Name", "Value"},
+			rows:    [][]string{{"n1", "v1"}, {"n2", "v2"}},
+			want: `+------+-------+
+| NAME | VALUE |
++------+-------+
+| n1   | v1    |
++------+-------+
+| n2   | v2    |
++------+-------+
+`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			buf := &bytes.Buffer{}
+			f := &TableOutputFormatter{
+				Headers: tt.headers,
+				Rows:    tt.rows,
+				Out:     buf,
+			}
+			err := f.Display()
+			assert.NoError(t, err)
+			assert.Equal(t, tt.want, buf.String())
+		})
+	}
+}
+
+func TestJSONOutputFormatter_Display(t *testing.T) {
+	tests := []struct {
+		name string
+		data []interface{}
+		want string
+	}{
+		{
+			name: "simple object",
+			data: []interface{}{map[string]string{"k1": "v1"}, map[string]string{"k2": "v2"}},
+			want: "[\n  {\n    \"k1\": \"v1\"\n  },\n  {\n    \"k2\": \"v2\"\n  }\n]\n",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			buf := &bytes.Buffer{}
+			f := &JSONOutputFormatter[interface{}]{
+				Data: tt.data,
+				Out:  buf,
+			}
+			err := f.Display()
+			assert.NoError(t, err)
+			assert.Equal(t, tt.want, buf.String())
+		})
+	}
+}
+
+func TestYAMLOutputFormatter_Display(t *testing.T) {
+	tests := []struct {
+		name string
+		data []interface{}
+		want string
+	}{
+		{
+			name: "simple object",
+			data: []interface{}{map[string]string{"k1": "v1"}, map[string]string{"k2": "v2"}},
+			want: "- k1: v1\n- k2: v2\n",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			buf := &bytes.Buffer{}
+			f := &YAMLOutputFormatter[interface{}]{
+				Data: tt.data,
+				Out:  buf,
+			}
+			err := f.Display()
+			assert.NoError(t, err)
+			assert.Equal(t, tt.want, buf.String())
+		})
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -11,8 +11,11 @@ require (
 	oras.land/oras-go/v2 v2.5.0
 )
 
+require github.com/mattn/go-runewidth v0.0.9 // indirect
+
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/olekukonko/tablewriter v0.0.5
 	github.com/opencontainers/go-digest v1.0.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	golang.org/x/sync v0.12.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,11 @@
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/mattn/go-runewidth v0.0.9 h1:Lm995f3rfxdpd6TSmuVCHVb/QhupuXlYr8sCI/QdE+0=
+github.com/mattn/go-runewidth v0.0.9/go.mod h1:H031xJmbD/WCDINGzjvQ9THkh0rPKHF+m2gUSrubnMI=
 github.com/mitchellh/mapstructure v1.5.0 h1:jeMsZIYE/09sWLaz43PL7Gy6RuMjD2eJVyuac5Z2hdY=
 github.com/mitchellh/mapstructure v1.5.0/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
+github.com/olekukonko/tablewriter v0.0.5 h1:P2Ga83D34wi1o9J6Wh1mRuqd4mF/x/lgBS7N7AbDhec=
+github.com/olekukonko/tablewriter v0.0.5/go.mod h1:hPp6KlRPjbx+hW8ykQs1w3UBbZlj6HuIJcUGPhkA7kY=
 github.com/opencontainers/go-digest v1.0.0 h1:apOUWs51W5PlhuyGyz9FCeeBIOUDA/6nW8Oi/yOhh5U=
 github.com/opencontainers/go-digest v1.0.0/go.mod h1:0JzlMkj0TRzQZfJkVvzbP0HBR3IKzErnv2BNG4W4MAM=
 github.com/opencontainers/image-spec v1.1.1 h1:y0fUlFfIZhPF1W537XOLg0/fcx6zcHCJwooC2xJA040=


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->

Import output formatter library from score-compose implementation to avoid duplication of code between score-xxx cli implementation

#### What does this PR do?
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Relates to score-spec/score-k8s#112

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New chore (expected functionality to be implemented)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [x] I've signed off with an email address that matches the commit author.
