### PR TITLE
Ordered Container Start in Score - `containers.*.before.containers|ready`

### DIFF
--- a/loader/validate.go
+++ b/loader/validate.go
@@ -116,6 +116,12 @@ func listAllPlaceholders(workload *types.Workload) []string {
 // - The first element in a placeholder must be "resources" or "metadata"
 //
 // - All resource placeholders must resolve to a resource in the workload
+//
+// - All container names referenced in before entries must exist
+//
+// - A container may not reference itself in a before entry
+//
+// - The before relationships must not contain cycles
 func Validate(workload *types.Workload) error {
 	errMsgs := []string{}
 	placeholders := listAllPlaceholders(workload)
@@ -140,6 +146,59 @@ func Validate(workload *types.Workload) error {
 			errMsgs = append(errMsgs, fmt.Sprintf("placeholder ${%s} has unsupported first element of \"%s\"", placeholder, placeholderParts[0]))
 		}
 	}
+
+	// Validate container before relationships.
+	containerNames := make(map[string]struct{}, len(workload.Containers))
+	for name := range workload.Containers {
+		containerNames[name] = struct{}{}
+	}
+	// waitingFor[A] = list of containers that A must wait for (A's before dependencies).
+	waitingFor := make(map[string][]string)
+	for containerName, container := range workload.Containers {
+		for _, beforeElem := range container.Before {
+			for _, dep := range beforeElem.Containers {
+				if dep == containerName {
+					errMsgs = append(errMsgs, fmt.Sprintf("container %q has a self-referencing before entry", containerName))
+					continue
+				}
+				if _, exists := containerNames[dep]; !exists {
+					errMsgs = append(errMsgs, fmt.Sprintf("container %q before refers to unknown container %q", containerName, dep))
+					continue
+				}
+				waitingFor[containerName] = append(waitingFor[containerName], dep)
+			}
+		}
+	}
+	// DFS cycle detection using white/gray/black coloring.
+	const (
+		white = 0
+		gray  = 1
+		black = 2
+	)
+	color := make(map[string]int)
+	var dfs func(node string) bool
+	dfs = func(node string) bool {
+		color[node] = gray
+		for _, dep := range waitingFor[node] {
+			if color[dep] == gray {
+				return true
+			}
+			if color[dep] == white {
+				if dfs(dep) {
+					return true
+				}
+			}
+		}
+		color[node] = black
+		return false
+	}
+	for name := range workload.Containers {
+		if color[name] == white && dfs(name) {
+			errMsgs = append(errMsgs, "containers before relationships contain a cycle")
+			break
+		}
+	}
+
 	if len(errMsgs) > 0 {
 		return &ValidationError{
 			Messages: errMsgs,

--- a/loader/validate_test.go
+++ b/loader/validate_test.go
@@ -22,6 +22,14 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func workloadWithContainers(containers types.WorkloadContainers) *types.Workload {
+	return &types.Workload{
+		ApiVersion: "score.dev/v1b1",
+		Metadata:   types.WorkloadMetadata{"name": "test"},
+		Containers: containers,
+	}
+}
+
 func workloadWith(files types.ContainerFiles, variables types.ContainerVariables, volumes types.ContainerVolumes, resources types.WorkloadResources) *types.Workload {
 	return &types.Workload{
 		ApiVersion: "score.dev/v1b1",
@@ -102,7 +110,7 @@ func TestValidatePlaceholders(t *testing.T) {
 					Content: stringRef("No placeholders"),
 				},
 				"/usr/local/four": {
-					Content: stringRef("Escaped $${plaholder}"),
+					Content: stringRef("Escaped $${placeholder}"),
 				},
 				"/usr/local/five": {
 					Content:  stringRef("Invalid placeholder with NoExpand: ${this is invalid}"),
@@ -208,6 +216,111 @@ func TestValidatePlaceholders(t *testing.T) {
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
 			workload := workloadWith(testCase.files, testCase.variables, testCase.volumes, testCase.resources)
+			err := Validate(workload)
+			if len(testCase.errorContains) == 0 {
+				assert.NoError(t, err)
+				return
+			}
+			require.Error(t, err)
+			for _, msg := range testCase.errorContains {
+				assert.ErrorContains(t, err, msg)
+			}
+		})
+	}
+}
+
+func ready(r types.ContainerBeforeElemReady) *types.ContainerBeforeElemReady { return &r }
+
+func before(containers ...string) types.ContainerBeforeElem {
+	return types.ContainerBeforeElem{Containers: containers, Ready: ready(types.ContainerBeforeElemReadyStarted)}
+}
+
+func TestValidateContainerBefore(t *testing.T) {
+	testCases := []struct {
+		name          string
+		containers    types.WorkloadContainers
+		errorContains []string
+	}{
+		{
+			name: "no before",
+			containers: types.WorkloadContainers{
+				"a": {Image: "img"},
+				"b": {Image: "img"},
+			},
+		},
+		{
+			name: "valid linear chain",
+			containers: types.WorkloadContainers{
+				"a": {Image: "img", Before: []types.ContainerBeforeElem{before("b")}},
+				"b": {Image: "img", Before: []types.ContainerBeforeElem{before("c")}},
+				"c": {Image: "img"},
+			},
+		},
+		{
+			name: "valid diamond",
+			containers: types.WorkloadContainers{
+				"a": {Image: "img", Before: []types.ContainerBeforeElem{before("b", "c")}},
+				"b": {Image: "img", Before: []types.ContainerBeforeElem{before("d")}},
+				"c": {Image: "img", Before: []types.ContainerBeforeElem{before("d")}},
+				"d": {Image: "img"},
+			},
+		},
+		{
+			name: "unknown container",
+			containers: types.WorkloadContainers{
+				"a": {Image: "img", Before: []types.ContainerBeforeElem{before("nonexistent")}},
+			},
+			errorContains: []string{`container "a" before refers to unknown container "nonexistent"`},
+		},
+		{
+			name: "self reference",
+			containers: types.WorkloadContainers{
+				"a": {Image: "img", Before: []types.ContainerBeforeElem{before("a")}},
+			},
+			errorContains: []string{`container "a" has a self-referencing before entry`},
+		},
+		{
+			name: "two-node cycle",
+			containers: types.WorkloadContainers{
+				"a": {Image: "img", Before: []types.ContainerBeforeElem{before("b")}},
+				"b": {Image: "img", Before: []types.ContainerBeforeElem{before("a")}},
+			},
+			errorContains: []string{"containers before relationships contain a cycle"},
+		},
+		{
+			name: "three-node cycle",
+			containers: types.WorkloadContainers{
+				"a": {Image: "img", Before: []types.ContainerBeforeElem{before("b")}},
+				"b": {Image: "img", Before: []types.ContainerBeforeElem{before("c")}},
+				"c": {Image: "img", Before: []types.ContainerBeforeElem{before("a")}},
+			},
+			errorContains: []string{"containers before relationships contain a cycle"},
+		},
+		{
+			name: "multiple unknown containers",
+			containers: types.WorkloadContainers{
+				"a": {Image: "img", Before: []types.ContainerBeforeElem{before("x", "y")}},
+			},
+			errorContains: []string{
+				`container "a" before refers to unknown container "x"`,
+				`container "a" before refers to unknown container "y"`,
+			},
+		},
+		{
+			name: "unknown and cycle are both reported",
+			containers: types.WorkloadContainers{
+				"a": {Image: "img", Before: []types.ContainerBeforeElem{before("ghost"), before("b")}},
+				"b": {Image: "img", Before: []types.ContainerBeforeElem{before("a")}},
+			},
+			errorContains: []string{
+				`container "a" before refers to unknown container "ghost"`,
+				"containers before relationships contain a cycle",
+			},
+		},
+	}
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			workload := workloadWithContainers(testCase.containers)
 			err := Validate(workload)
 			if len(testCase.errorContains) == 0 {
 				assert.NoError(t, err)

--- a/schema/files/score-v1b1.json
+++ b/schema/files/score-v1b1.json
@@ -367,6 +367,38 @@
             }
           ]
         },
+        "before": {
+          "description": "A list of containers which should run before a main process.",
+          "type": "array",
+          "additionalProperties": false,
+          "required": ["containers", "ready"],
+          "items": {
+            "type": "object",
+            "properties": {
+              "containers": {
+                "description": "The list of containers to run before the main process.",
+                "type": "array",
+                "items": {
+                  "type": "string",
+                  "description": "A container ID in this implementation.",
+                  "minLength": 2,
+                  "maxLength": 63,
+                  "pattern": "^[a-z0-9][a-z0-9-]{0,61}[a-z0-9]$"
+                }
+              },
+              "ready": {
+                "description": "The status of the container before the next container are started.",
+                "title": "Ready",
+                "type": "string",
+                "enum": [
+                  "started",
+                  "healthy",
+                  "complete"
+                ]
+              }
+            }
+          }
+        },
         "resources": {
           "description": "The compute resources for the container.",
           "type": "object",

--- a/schema/files/score-v1b1.json.for-validation
+++ b/schema/files/score-v1b1.json.for-validation
@@ -310,6 +310,41 @@
             "$ref": "#/$defs/containerVolume"
           }
         },
+        "before": {
+          "description": "A list of containers which should run before a main process.",
+          "type": "array",
+          "additionalProperties": false,
+          "required": [
+            "containers",
+            "ready"
+          ],
+          "items": {
+            "type": "object",
+            "properties": {
+              "containers": {
+                "description": "The list of containers to run before the main process.",
+                "type": "array",
+                "items": {
+                  "type": "string",
+                  "description": "A container ID in this implementation.",
+                  "minLength": 2,
+                  "maxLength": 63,
+                  "pattern": "^[a-z0-9][a-z0-9-]{0,61}[a-z0-9]$"
+                }
+              },
+              "ready": {
+                "description": "The status of the container before the next container are started.",
+                "title": "Ready",
+                "type": "string",
+                "enum": [
+                  "started",
+                  "healthy",
+                  "complete"
+                ]
+              }
+            }
+          }
+        },
         "resources": {
           "description": "The compute resources for the container.",
           "type": "object",


### PR DESCRIPTION
Ordered Container Start in Score - `containers.*.before.containers|ready`

TODOs:
- [x] Add business logic here in `score-go` that could be reused by concrete implementations 
- [x] Integrate this branch in `score-compose` to start the implementation
  - [ ] https://github.com/score-spec/score-compose/pull/454

_Note: the integration in `score-k8s` will be done later._