### PR TITLE
feat: add before field mapping to container schema and types

### DIFF
--- a/loader/validate.go
+++ b/loader/validate.go
@@ -155,18 +155,16 @@ func Validate(workload *types.Workload) error {
 	// waitingFor[A] = list of containers that A must wait for (A's before dependencies).
 	waitingFor := make(map[string][]string)
 	for containerName, container := range workload.Containers {
-		for _, beforeElem := range container.Before {
-			for _, dep := range beforeElem.Containers {
-				if dep == containerName {
-					errMsgs = append(errMsgs, fmt.Sprintf("container %q has a self-referencing before entry", containerName))
-					continue
-				}
-				if _, exists := containerNames[dep]; !exists {
-					errMsgs = append(errMsgs, fmt.Sprintf("container %q before refers to unknown container %q", containerName, dep))
-					continue
-				}
-				waitingFor[containerName] = append(waitingFor[containerName], dep)
+		for dep := range container.Before {
+			if dep == containerName {
+				errMsgs = append(errMsgs, fmt.Sprintf("container %q has a self-referencing before entry", containerName))
+				continue
 			}
+			if _, exists := containerNames[dep]; !exists {
+				errMsgs = append(errMsgs, fmt.Sprintf("container %q before refers to unknown container %q", containerName, dep))
+				continue
+			}
+			waitingFor[containerName] = append(waitingFor[containerName], dep)
 		}
 	}
 	// DFS cycle detection using white/gray/black coloring.

--- a/loader/validate_test.go
+++ b/loader/validate_test.go
@@ -229,10 +229,12 @@ func TestValidatePlaceholders(t *testing.T) {
 	}
 }
 
-func ready(r types.ContainerBeforeElemReady) *types.ContainerBeforeElemReady { return &r }
-
-func before(containers ...string) types.ContainerBeforeElem {
-	return types.ContainerBeforeElem{Containers: containers, Ready: ready(types.ContainerBeforeElemReadyStarted)}
+func before(containers ...string) types.ContainerBefore {
+	b := types.ContainerBefore{}
+	for _, c := range containers {
+		b[c] = types.ContainerBeforeEntry{Ready: types.ContainerBeforeReadyStarted}
+	}
+	return b
 }
 
 func TestValidateContainerBefore(t *testing.T) {
@@ -251,55 +253,55 @@ func TestValidateContainerBefore(t *testing.T) {
 		{
 			name: "valid linear chain",
 			containers: types.WorkloadContainers{
-				"a": {Image: "img", Before: []types.ContainerBeforeElem{before("b")}},
-				"b": {Image: "img", Before: []types.ContainerBeforeElem{before("c")}},
+				"a": {Image: "img", Before: before("b")},
+				"b": {Image: "img", Before: before("c")},
 				"c": {Image: "img"},
 			},
 		},
 		{
 			name: "valid diamond",
 			containers: types.WorkloadContainers{
-				"a": {Image: "img", Before: []types.ContainerBeforeElem{before("b", "c")}},
-				"b": {Image: "img", Before: []types.ContainerBeforeElem{before("d")}},
-				"c": {Image: "img", Before: []types.ContainerBeforeElem{before("d")}},
+				"a": {Image: "img", Before: before("b", "c")},
+				"b": {Image: "img", Before: before("d")},
+				"c": {Image: "img", Before: before("d")},
 				"d": {Image: "img"},
 			},
 		},
 		{
 			name: "unknown container",
 			containers: types.WorkloadContainers{
-				"a": {Image: "img", Before: []types.ContainerBeforeElem{before("nonexistent")}},
+				"a": {Image: "img", Before: before("nonexistent")},
 			},
 			errorContains: []string{`container "a" before refers to unknown container "nonexistent"`},
 		},
 		{
 			name: "self reference",
 			containers: types.WorkloadContainers{
-				"a": {Image: "img", Before: []types.ContainerBeforeElem{before("a")}},
+				"a": {Image: "img", Before: before("a")},
 			},
 			errorContains: []string{`container "a" has a self-referencing before entry`},
 		},
 		{
 			name: "two-node cycle",
 			containers: types.WorkloadContainers{
-				"a": {Image: "img", Before: []types.ContainerBeforeElem{before("b")}},
-				"b": {Image: "img", Before: []types.ContainerBeforeElem{before("a")}},
+				"a": {Image: "img", Before: before("b")},
+				"b": {Image: "img", Before: before("a")},
 			},
 			errorContains: []string{"containers before relationships contain a cycle"},
 		},
 		{
 			name: "three-node cycle",
 			containers: types.WorkloadContainers{
-				"a": {Image: "img", Before: []types.ContainerBeforeElem{before("b")}},
-				"b": {Image: "img", Before: []types.ContainerBeforeElem{before("c")}},
-				"c": {Image: "img", Before: []types.ContainerBeforeElem{before("a")}},
+				"a": {Image: "img", Before: before("b")},
+				"b": {Image: "img", Before: before("c")},
+				"c": {Image: "img", Before: before("a")},
 			},
 			errorContains: []string{"containers before relationships contain a cycle"},
 		},
 		{
 			name: "multiple unknown containers",
 			containers: types.WorkloadContainers{
-				"a": {Image: "img", Before: []types.ContainerBeforeElem{before("x", "y")}},
+				"a": {Image: "img", Before: before("x", "y")},
 			},
 			errorContains: []string{
 				`container "a" before refers to unknown container "x"`,
@@ -309,8 +311,11 @@ func TestValidateContainerBefore(t *testing.T) {
 		{
 			name: "unknown and cycle are both reported",
 			containers: types.WorkloadContainers{
-				"a": {Image: "img", Before: []types.ContainerBeforeElem{before("ghost"), before("b")}},
-				"b": {Image: "img", Before: []types.ContainerBeforeElem{before("a")}},
+				"a": {Image: "img", Before: types.ContainerBefore{
+					"ghost": {Ready: types.ContainerBeforeReadyStarted},
+					"b":     {Ready: types.ContainerBeforeReadyStarted},
+				}},
+				"b": {Image: "img", Before: before("a")},
 			},
 			errorContains: []string{
 				`container "a" before refers to unknown container "ghost"`,
@@ -333,3 +338,4 @@ func TestValidateContainerBefore(t *testing.T) {
 		})
 	}
 }
+

--- a/schema/files/score-v1b1.json
+++ b/schema/files/score-v1b1.json
@@ -368,26 +368,20 @@
           ]
         },
         "before": {
-          "description": "A list of containers which should run before a main process.",
-          "type": "array",
-          "additionalProperties": false,
-          "required": ["containers", "ready"],
-          "items": {
+          "description": "Defines before which other containers this container should be started.",
+          "type": "object",
+          "propertyNames": {
+            "minLength": 2,
+            "maxLength": 63,
+            "pattern": "^[a-z0-9][a-z0-9-]{0,61}[a-z0-9]$"
+          },
+          "additionalProperties": {
             "type": "object",
+            "required": ["ready"],
+            "additionalProperties": false,
             "properties": {
-              "containers": {
-                "description": "The list of containers to run before the main process.",
-                "type": "array",
-                "items": {
-                  "type": "string",
-                  "description": "A container ID in this implementation.",
-                  "minLength": 2,
-                  "maxLength": 63,
-                  "pattern": "^[a-z0-9][a-z0-9-]{0,61}[a-z0-9]$"
-                }
-              },
               "ready": {
-                "description": "The status of the container before the next container are started.",
+                "description": "The status of the container before the next containers are started.",
                 "title": "Ready",
                 "type": "string",
                 "enum": [
@@ -411,32 +405,6 @@
             "requests": {
               "description": "The minimal resources required for the container.",
               "$ref": "#/$defs/resourcesLimits"
-            }
-          }
-        },
-        "before": {
-          "description": "Defines before which other containers this container should be started.",
-          "type": "object",
-          "propertyNames": {
-            "minLength": 2,
-            "maxLength": 63,
-            "pattern": "^[a-z0-9][a-z0-9-]{0,61}[a-z0-9]$"
-          },
-          "additionalProperties": {
-            "type": "object",
-            "required": ["ready"],
-            "additionalProperties": false,
-            "properties": {
-              "ready": {
-                "description": "The status of the container before the next containers are started.",
-                "title": "Ready",
-                "type": "string",
-                "enum": [
-                  "started",
-                  "healthy",
-                  "complete"
-                ]
-              }
             }
           }
         },

--- a/schema/files/score-v1b1.json
+++ b/schema/files/score-v1b1.json
@@ -414,6 +414,32 @@
             }
           }
         },
+        "before": {
+          "description": "Defines before which other containers this container should be started.",
+          "type": "object",
+          "propertyNames": {
+            "minLength": 2,
+            "maxLength": 63,
+            "pattern": "^[a-z0-9][a-z0-9-]{0,61}[a-z0-9]$"
+          },
+          "additionalProperties": {
+            "type": "object",
+            "required": ["ready"],
+            "additionalProperties": false,
+            "properties": {
+              "ready": {
+                "description": "The status of the container before the next containers are started.",
+                "title": "Ready",
+                "type": "string",
+                "enum": [
+                  "started",
+                  "healthy",
+                  "complete"
+                ]
+              }
+            }
+          }
+        },
         "livenessProbe": {
           "description": "The liveness probe for the container.",
           "$ref": "#/$defs/containerProbe"

--- a/schema/files/score-v1b1.json
+++ b/schema/files/score-v1b1.json
@@ -368,7 +368,7 @@
           ]
         },
         "before": {
-          "description": "Defines before which other containers this container should be started.",
+          "description": "Containers which should be started before this container.",
           "type": "object",
           "propertyNames": {
             "minLength": 2,
@@ -381,7 +381,7 @@
             "additionalProperties": false,
             "properties": {
               "ready": {
-                "description": "The status of the container before the next containers are started.",
+                "description": "The status of the container before the next container is started.",
                 "title": "Ready",
                 "type": "string",
                 "enum": [

--- a/schema/files/score-v1b1.json.for-validation
+++ b/schema/files/score-v1b1.json.for-validation
@@ -311,56 +311,6 @@
           }
         },
         "before": {
-          "description": "A list of containers which should run before a main process.",
-          "type": "array",
-          "additionalProperties": false,
-          "required": [
-            "containers",
-            "ready"
-          ],
-          "items": {
-            "type": "object",
-            "properties": {
-              "containers": {
-                "description": "The list of containers to run before the main process.",
-                "type": "array",
-                "items": {
-                  "type": "string",
-                  "description": "A container ID in this implementation.",
-                  "minLength": 2,
-                  "maxLength": 63,
-                  "pattern": "^[a-z0-9][a-z0-9-]{0,61}[a-z0-9]$"
-                }
-              },
-              "ready": {
-                "description": "The status of the container before the next container are started.",
-                "title": "Ready",
-                "type": "string",
-                "enum": [
-                  "started",
-                  "healthy",
-                  "complete"
-                ]
-              }
-            }
-          }
-        },
-        "resources": {
-          "description": "The compute resources for the container.",
-          "type": "object",
-          "additionalProperties": false,
-          "properties": {
-            "limits": {
-              "description": "The maximum allowed resources for the container.",
-              "$ref": "#/$defs/resourcesLimits"
-            },
-            "requests": {
-              "description": "The minimal resources required for the container.",
-              "$ref": "#/$defs/resourcesLimits"
-            }
-          }
-        },
-        "before": {
           "description": "Defines before which other containers this container should be started.",
           "type": "object",
           "propertyNames": {
@@ -385,6 +335,21 @@
                   "complete"
                 ]
               }
+            }
+          }
+        },
+        "resources": {
+          "description": "The compute resources for the container.",
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "limits": {
+              "description": "The maximum allowed resources for the container.",
+              "$ref": "#/$defs/resourcesLimits"
+            },
+            "requests": {
+              "description": "The minimal resources required for the container.",
+              "$ref": "#/$defs/resourcesLimits"
             }
           }
         },

--- a/schema/files/score-v1b1.json.for-validation
+++ b/schema/files/score-v1b1.json.for-validation
@@ -360,6 +360,34 @@
             }
           }
         },
+        "before": {
+          "description": "Defines before which other containers this container should be started.",
+          "type": "object",
+          "propertyNames": {
+            "minLength": 2,
+            "maxLength": 63,
+            "pattern": "^[a-z0-9][a-z0-9-]{0,61}[a-z0-9]$"
+          },
+          "additionalProperties": {
+            "type": "object",
+            "required": [
+              "ready"
+            ],
+            "additionalProperties": false,
+            "properties": {
+              "ready": {
+                "description": "The status of the container before the next containers are started.",
+                "title": "Ready",
+                "type": "string",
+                "enum": [
+                  "started",
+                  "healthy",
+                  "complete"
+                ]
+              }
+            }
+          }
+        },
         "livenessProbe": {
           "description": "The liveness probe for the container.",
           "$ref": "#/$defs/containerProbe"

--- a/schema/files/score-v1b1.json.for-validation
+++ b/schema/files/score-v1b1.json.for-validation
@@ -311,7 +311,7 @@
           }
         },
         "before": {
-          "description": "Defines before which other containers this container should be started.",
+          "description": "Containers which should be started before this container.",
           "type": "object",
           "propertyNames": {
             "minLength": 2,
@@ -326,7 +326,7 @@
             "additionalProperties": false,
             "properties": {
               "ready": {
-                "description": "The status of the container before the next containers are started.",
+                "description": "The status of the container before the next container is started.",
                 "title": "Ready",
                 "type": "string",
                 "enum": [

--- a/schema/schema_test.go
+++ b/schema/schema_test.go
@@ -931,7 +931,7 @@ func TestSchema(t *testing.T) {
 		// containers.*.before
 		//
 		{
-			Name: "containers.*.before is not set",
+			Name: "containers.*.before is null",
 			Src: func() map[string]interface{} {
 				src := newTestDocument()
 				var hello = src["containers"].(map[string]interface{})["hello"].(map[string]interface{})

--- a/schema/schema_test.go
+++ b/schema/schema_test.go
@@ -928,6 +928,112 @@ func TestSchema(t *testing.T) {
 			Message: "/containers/hello/resources/requests/cpu",
 		},
 
+		// containers.*.before
+		//
+		{
+			Name: "containers.*.before is not set",
+			Src: func() map[string]interface{} {
+				src := newTestDocument()
+				var hello = src["containers"].(map[string]interface{})["hello"].(map[string]interface{})
+				hello["before"] = nil
+				return src
+			}(),
+			Message: "/containers/hello/before",
+		},
+		{
+			Name: "containers.*.before is empty",
+			Src: func() map[string]interface{} {
+				src := newTestDocument()
+				var hello = src["containers"].(map[string]interface{})["hello"].(map[string]interface{})
+				hello["before"] = map[string]interface{}{}
+				return src
+			}(),
+			Message: "",
+		},
+		{
+			Name: "containers.*.before with valid ready condition",
+			Src: func() map[string]interface{} {
+				src := newTestDocument()
+				var hello = src["containers"].(map[string]interface{})["hello"].(map[string]interface{})
+				hello["before"] = map[string]interface{}{
+					"other-container": map[string]interface{}{
+						"ready": "complete",
+					},
+				}
+				return src
+			}(),
+			Message: "",
+		},
+		{
+			Name: "containers.*.before with started ready condition",
+			Src: func() map[string]interface{} {
+				src := newTestDocument()
+				var hello = src["containers"].(map[string]interface{})["hello"].(map[string]interface{})
+				hello["before"] = map[string]interface{}{
+					"other-container": map[string]interface{}{
+						"ready": "started",
+					},
+				}
+				return src
+			}(),
+			Message: "",
+		},
+		{
+			Name: "containers.*.before with healthy ready condition",
+			Src: func() map[string]interface{} {
+				src := newTestDocument()
+				var hello = src["containers"].(map[string]interface{})["hello"].(map[string]interface{})
+				hello["before"] = map[string]interface{}{
+					"other-container": map[string]interface{}{
+						"ready": "healthy",
+					},
+				}
+				return src
+			}(),
+			Message: "",
+		},
+		{
+			Name: "containers.*.before.*.ready is invalid",
+			Src: func() map[string]interface{} {
+				src := newTestDocument()
+				var hello = src["containers"].(map[string]interface{})["hello"].(map[string]interface{})
+				hello["before"] = map[string]interface{}{
+					"other-container": map[string]interface{}{
+						"ready": "running",
+					},
+				}
+				return src
+			}(),
+			Message: "/containers/hello/before/other-container/ready",
+		},
+		{
+			Name: "containers.*.before.*.ready is missing",
+			Src: func() map[string]interface{} {
+				src := newTestDocument()
+				var hello = src["containers"].(map[string]interface{})["hello"].(map[string]interface{})
+				hello["before"] = map[string]interface{}{
+					"other-container": map[string]interface{}{},
+				}
+				return src
+			}(),
+			Message: "/containers/hello/before/other-container",
+		},
+		{
+			Name: "containers.*.before.* has extra property",
+			Src: func() map[string]interface{} {
+				src := newTestDocument()
+				var hello = src["containers"].(map[string]interface{})["hello"].(map[string]interface{})
+				hello["before"] = map[string]interface{}{
+					"other-container": map[string]interface{}{
+						"ready":   "complete",
+						"timeout": "30s",
+					},
+				}
+				return src
+			}(),
+			Message: "/containers/hello/before/other-container",
+		},
+
 		// containers.*.livenessProbe
 		//
 		{

--- a/types/types.gen.go
+++ b/types/types.gen.go
@@ -11,8 +11,9 @@ type Container struct {
 	// If specified, overrides the arguments passed to the container entrypoint.
 	Args []string `json:"args,omitempty" yaml:"args,omitempty" mapstructure:"args,omitempty"`
 
-	// A list of containers which should run before a main process.
-	Before []ContainerBeforeElem `json:"before,omitempty" yaml:"before,omitempty" mapstructure:"before,omitempty"`
+	// Defines before which other containers this container should be started.
+	Before ContainerBefore `json:"before,omitempty" yaml:"before,omitempty" mapstructure:"before,omitempty"`
+
 
 	// If specified, overrides the entrypoint defined in the container image.
 	Command []string `json:"command,omitempty" yaml:"command,omitempty" mapstructure:"command,omitempty"`
@@ -39,19 +40,23 @@ type Container struct {
 	Volumes ContainerVolumes `json:"volumes,omitempty" yaml:"volumes,omitempty" mapstructure:"volumes,omitempty"`
 }
 
-type ContainerBeforeElem struct {
-	// The list of containers to run before the main process.
-	Containers []string `json:"containers,omitempty" yaml:"containers,omitempty" mapstructure:"containers,omitempty"`
+// ContainerBefore is a mapping of container names to their ready conditions,
+// defining which containers must reach a certain state before this container starts.
+type ContainerBefore map[string]ContainerBeforeEntry
 
-	// The status of the container before the next container are started.
-	Ready *ContainerBeforeElemReady `json:"ready,omitempty" yaml:"ready,omitempty" mapstructure:"ready,omitempty"`
+// ContainerBeforeEntry defines the ready condition for a container in the before mapping.
+type ContainerBeforeEntry struct {
+	// The status of the container before the next containers are started.
+	Ready ContainerBeforeReady `json:"ready" yaml:"ready" mapstructure:"ready"`
 }
 
-type ContainerBeforeElemReady string
+// ContainerBeforeReady represents the ready condition for ordered container start.
+type ContainerBeforeReady string
 
-const ContainerBeforeElemReadyComplete ContainerBeforeElemReady = "complete"
-const ContainerBeforeElemReadyHealthy ContainerBeforeElemReady = "healthy"
-const ContainerBeforeElemReadyStarted ContainerBeforeElemReady = "started"
+const ContainerBeforeReadyStarted  ContainerBeforeReady = "started"
+const ContainerBeforeReadyHealthy  ContainerBeforeReady = "healthy"
+const ContainerBeforeReadyComplete ContainerBeforeReady = "complete"
+
 
 // The details of a file to mount in the container. One of 'source', 'content', or
 // 'binaryContent' must be provided.

--- a/types/types.gen.go
+++ b/types/types.gen.go
@@ -228,7 +228,7 @@ func (j *ExecProbe) UnmarshalJSON(b []byte) error {
 	return nil
 }
 
-var enumValues_ContainerBeforeElemReady = []interface{}{
+var enumValues_ContainerBeforeReady = []interface{}{
 	"started",
 	"healthy",
 	"complete",
@@ -397,22 +397,22 @@ func (j *ServicePortProtocol) UnmarshalJSON(b []byte) error {
 }
 
 // UnmarshalJSON implements json.Unmarshaler.
-func (j *ContainerBeforeElemReady) UnmarshalJSON(b []byte) error {
+func (j *ContainerBeforeReady) UnmarshalJSON(b []byte) error {
 	var v string
 	if err := json.Unmarshal(b, &v); err != nil {
 		return err
 	}
 	var ok bool
-	for _, expected := range enumValues_ContainerBeforeElemReady {
+	for _, expected := range enumValues_ContainerBeforeReady {
 		if reflect.DeepEqual(v, expected) {
 			ok = true
 			break
 		}
 	}
 	if !ok {
-		return fmt.Errorf("invalid value (expected one of %#v): %#v", enumValues_ContainerBeforeElemReady, v)
+		return fmt.Errorf("invalid value (expected one of %#v): %#v", enumValues_ContainerBeforeReady, v)
 	}
-	*j = ContainerBeforeElemReady(v)
+	*j = ContainerBeforeReady(v)
 	return nil
 }
 


### PR DESCRIPTION
#### Description
This follows up on score-spec/spec#186 where the `before` field schema was refactored from array to per-container mapping. This PR integrates that same schema change into score-go, following the same approach as #121.


#### What does this PR do?
- Adds the `before` field to the container schema in `schema/files/score-v1b1.json`.
- Regenerates `score-v1b1.json.for-validation` via the `make generate` jq transformation.
- Adds `ContainerBefore`, `ContainerBeforeEntry`, and `ContainerBeforeReady` types to `types/types.gen.go`.
- Adds schema validation tests for the `before` field in `schema/schema_test.go`.

The new structure:

```
containers:
  init:
    image: busybox
    before:
      main:
        ready: complete
  main:
    image: myapp
```

#### Types of changes
- [x] New feature (non-breaking change which adds functionality)

#### Checklist:
- [x] I've signed off with an email address that matches the commit author.
