### PR TITLE
feat: add support for importing multiple files from a local directory

### DIFF
--- a/uriget/example_test.go
+++ b/uriget/example_test.go
@@ -17,9 +17,11 @@ package uriget
 import (
 	"context"
 	"fmt"
+	"log"
 	"net/http"
 	"net/url"
 	"os"
+	"path/filepath"
 	"testing"
 )
 
@@ -163,4 +165,123 @@ func ExampleGetFile_oci_https() {
 	fmt.Println(len(ociBuff) == len(httpsbuff))
 	// Output:
 	// true
+}
+
+func ExampleGetFiles_local() {
+	results, err := GetFiles(context.Background(), "../README.md")
+	fmt.Println(len(results) == 1, len(results[0].Content) > 0, err)
+	// Output:
+	// true true <nil>
+}
+
+func TestGetFiles_SingleFile(t *testing.T) {
+	td := t.TempDir()
+	filePath := filepath.Join(td, "test.yaml")
+	if err := os.WriteFile(filePath, []byte("hello"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	results, err := GetFiles(context.Background(), filePath, WithLogger(log.New(os.Stderr, "", 0)))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(results) != 1 {
+		t.Fatalf("expected 1 result, got %d", len(results))
+	}
+	if string(results[0].Content) != "hello" {
+		t.Errorf("expected content 'hello', got '%s'", results[0].Content)
+	}
+}
+
+func TestGetFiles_Directory(t *testing.T) {
+	td := t.TempDir()
+	// Create files in non-alphabetical order to verify sorting
+	files := map[string]string{
+		"c-provisioner.yaml": "content-c",
+		"a-provisioner.yaml": "content-a",
+		"b-provisioner.yaml": "content-b",
+	}
+	for name, content := range files {
+		if err := os.WriteFile(filepath.Join(td, name), []byte(content), 0644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	results, err := GetFiles(context.Background(), td, WithLogger(log.New(os.Stderr, "", 0)))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(results) != 3 {
+		t.Fatalf("expected 3 results, got %d", len(results))
+	}
+	// Verify sorted order and full path URIs
+	expected := []struct {
+		uri     string
+		content string
+	}{
+		{filepath.Join(td, "a-provisioner.yaml"), "content-a"},
+		{filepath.Join(td, "b-provisioner.yaml"), "content-b"},
+		{filepath.Join(td, "c-provisioner.yaml"), "content-c"},
+	}
+	for i, e := range expected {
+		if results[i].URI != e.uri {
+			t.Errorf("result[%d]: expected URI '%s', got '%s'", i, e.uri, results[i].URI)
+		}
+		if string(results[i].Content) != e.content {
+			t.Errorf("result[%d]: expected content '%s', got '%s'", i, e.content, results[i].Content)
+		}
+	}
+}
+
+func TestGetFiles_DirectorySkipsSubdirs(t *testing.T) {
+	td := t.TempDir()
+	if err := os.WriteFile(filepath.Join(td, "file.yaml"), []byte("data"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Mkdir(filepath.Join(td, "subdir"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	results, err := GetFiles(context.Background(), td, WithLogger(log.New(os.Stderr, "", 0)))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(results) != 1 {
+		t.Fatalf("expected 1 result (subdir skipped), got %d", len(results))
+	}
+	if results[0].URI != filepath.Join(td, "file.yaml") {
+		t.Errorf("expected URI '%s', got '%s'", filepath.Join(td, "file.yaml"), results[0].URI)
+	}
+}
+
+func TestGetFiles_EmptyDirectory(t *testing.T) {
+	td := t.TempDir()
+	_, err := GetFiles(context.Background(), td, WithLogger(log.New(os.Stderr, "", 0)))
+	if err == nil {
+		t.Fatal("expected error for empty directory, got nil")
+	}
+}
+
+func TestGetFiles_NonExistentPath(t *testing.T) {
+	_, err := GetFiles(context.Background(), "/does/not/exist", WithLogger(log.New(os.Stderr, "", 0)))
+	if err == nil {
+		t.Fatal("expected error for non-existent path, got nil")
+	}
+}
+
+func TestGetFiles_DirectoryWithFileScheme(t *testing.T) {
+	td := t.TempDir()
+	if err := os.WriteFile(filepath.Join(td, "a.yaml"), []byte("aaa"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(td, "b.yaml"), []byte("bbb"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	results, err := GetFiles(context.Background(), "file://"+td, WithLogger(log.New(os.Stderr, "", 0)))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(results) != 2 {
+		t.Fatalf("expected 2 results, got %d", len(results))
+	}
+	if results[0].URI != filepath.Join(td, "a.yaml") || results[1].URI != filepath.Join(td, "b.yaml") {
+		t.Errorf("unexpected URIs: %s, %s", results[0].URI, results[1].URI)
+	}
 }

--- a/uriget/uriget.go
+++ b/uriget/uriget.go
@@ -29,6 +29,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"sort"
 	"strings"
 	"time"
 
@@ -39,6 +40,14 @@ import (
 	"oras.land/oras-go/v2/registry/remote/credentials"
 	"oras.land/oras-go/v2/registry/remote/retry"
 )
+
+// FileContent holds the URI and content of a file retrieved by GetFiles.
+type FileContent struct {
+	// URI is the URI or path of the file.
+	URI string
+	// Content is the raw bytes of the file.
+	Content []byte
+}
 
 // options is a struct holding fields that may need to have overrides in certain environments or during unit testing.
 // The options struct can be modified by using Option functions. See defaultOptions.
@@ -121,23 +130,50 @@ func GetFile(ctx context.Context, rawUri string, optionFuncs ...Option) ([]byte,
 		optionFunc(opts)
 	}
 	switch strings.ToLower(u.Scheme) {
-	case "http":
-		fallthrough
-	case "https":
+	case "http", "https":
 		return opts.getHttp(ctx, u)
-	case "file":
-		fallthrough
-	case "":
+	case "file", "":
 		return opts.getFile(ctx, u)
-	case "git-ssh":
-		fallthrough
-	case "git-https":
+	case "git-ssh", "git-https":
 		return opts.getGit(ctx, u)
 	case "oci":
 		return opts.getOci(ctx, u)
 	default:
 		return nil, fmt.Errorf("unsupported scheme '%s'", u.Scheme)
 	}
+}
+
+// GetFiles is like GetFile but with support for importing multiple files from a directory. Currently, directory
+// support is only implemented for the file scheme. For other schemes (http, git, oci), the target is treated as a
+// single file and returned as a single-element slice.
+//
+// TODO: Add directory support for git and oci schemes.
+func GetFiles(ctx context.Context, rawUri string, optionFuncs ...Option) ([]FileContent, error) {
+	u, err := url.Parse(rawUri)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse: %w", err)
+	}
+	opts := &options{}
+	for _, optionFunc := range append(defaultOptions, optionFuncs...) {
+		optionFunc(opts)
+	}
+	var content []byte
+	switch strings.ToLower(u.Scheme) {
+	case "file", "":
+		return opts.getFileOrDir(ctx, u)
+	case "http", "https":
+		content, err = opts.getHttp(ctx, u)
+	case "git-ssh", "git-https":
+		content, err = opts.getGit(ctx, u)
+	case "oci":
+		content, err = opts.getOci(ctx, u)
+	default:
+		return nil, fmt.Errorf("unsupported scheme '%s'", u.Scheme)
+	}
+	if err != nil {
+		return nil, err
+	}
+	return []FileContent{{URI: rawUri, Content: content}}, nil
 }
 
 func getStdinFile(ctx context.Context) ([]byte, error) {
@@ -217,6 +253,82 @@ func (o *options) getFile(ctx context.Context, u *url.URL) ([]byte, error) {
 	}
 	o.logger.Printf("Read %d bytes from %s", len(buff), targetPath)
 	return buff, nil
+}
+
+// getFileOrDir resolves a file:// or bare path URI. If the path is a directory, it reads all files (non-recursively)
+// sorted by name. If it's a single file, it returns a single-element slice.
+func (o *options) getFileOrDir(ctx context.Context, u *url.URL) ([]FileContent, error) {
+	targetPath := u.Host + u.Path
+	rawUri := u.String()
+	if rawUri == "-" {
+		content, err := getStdinFile(ctx)
+		if err != nil {
+			return nil, err
+		}
+		return []FileContent{{URI: "-", Content: content}}, nil
+	}
+
+	if strings.HasPrefix(targetPath, "~/") {
+		hd, err := os.UserHomeDir()
+		if err != nil {
+			return nil, fmt.Errorf("failed to find user home dir: %w", err)
+		}
+		targetPath = filepath.Join(hd, targetPath[2:])
+	}
+
+	info, err := os.Stat(targetPath)
+	if err != nil {
+		return nil, err
+	}
+
+	if !info.IsDir() {
+		f, err := os.Open(targetPath)
+		if err != nil {
+			return nil, err
+		}
+		defer func() { _ = f.Close() }()
+		buff, err := readLimited(f, o.limit)
+		if err != nil {
+			return nil, fmt.Errorf("failed to read file: %w", err)
+		}
+		o.logger.Printf("Read %d bytes from %s", len(buff), targetPath)
+		return []FileContent{{URI: targetPath, Content: buff}}, nil
+	}
+
+	entries, err := os.ReadDir(targetPath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read directory: %w", err)
+	}
+
+	// Filter to skip sub-directories
+	var fileNames []string
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			fileNames = append(fileNames, entry.Name())
+		}
+	}
+	sort.Strings(fileNames)
+
+	if len(fileNames) == 0 {
+		return nil, fmt.Errorf("directory %s contains no files", targetPath)
+	}
+
+	var out []FileContent
+	for _, name := range fileNames {
+		filePath := filepath.Join(targetPath, name)
+		f, err := os.Open(filePath)
+		if err != nil {
+			return nil, fmt.Errorf("failed to open %s: %w", filePath, err)
+		}
+		buff, err := readLimited(f, o.limit)
+		_ = f.Close()
+		if err != nil {
+			return nil, fmt.Errorf("failed to read %s: %w", filePath, err)
+		}
+		o.logger.Printf("Read %d bytes from %s", len(buff), filePath)
+		out = append(out, FileContent{URI: filePath, Content: buff})
+	}
+	return out, nil
 }
 
 func (o *options) getGit(ctx context.Context, u *url.URL) ([]byte, error) {


### PR DESCRIPTION
#### Description

Add a new GetFiles function to the uriget package that supports reading multiple files from a directory when the target path is a local directory. 
This also introduces a FileContent type to hold the URI and content of each file. The existing GetFile function is unchanged and fully backward compatible.

Additionally, the switch cases in GetFile have been refactored from fallthrough style to comma-separated style for consistency and idiomatic Go.

#### What does this PR do?

Fixes #177

When score-compose or score-k8s users pass a local directory path via --provisioners, the new GetFiles function reads all files in that directory (non-recursively), sorted by name, and returns them as a []FileContent slice. This enables importing multiple provisioner files from a folder in a single command.

For non-file schemes (http, git, oci) and single file paths, GetFiles returns a single-element slice, maintaining backward compatibility.

Directory support for git and oci schemes is not yet implemented and is tracked as a TODO for a future iteration.

#### Testing

**score-compose init**
```
./score-compose init \
  --no-default-provisioners=true \
  --provisioners ../community-provisioners/llm-model/score-compose
INFO: Found existing state directory '.score-compose'
INFO: Found existing Score file './score.yaml'
INFO: Read 622 bytes from ../community-provisioners/llm-model/score-compose/10-dmr-llm-model-for-openai-clients.provisioners.yaml
INFO: Read 685 bytes from ../community-provisioners/llm-model/score-compose/10-dmr-llm-model-via-curl-cmd.provisioners.yaml
INFO: Read 631 bytes from ../community-provisioners/llm-model/score-compose/10-dmr-llm-model-via-curl-service.provisioners.yaml
INFO: Read 723 bytes from ../community-provisioners/llm-model/score-compose/10-dmr-llm-model-via-service-provider.provisioners.yaml
INFO: Read 599 bytes from ../community-provisioners/llm-model/score-compose/10-dmr-llm-model.provisioners.yaml
INFO: Read 907 bytes from ../community-provisioners/llm-model/score-compose/10-ollama-llm-model-service.provisioners.yaml
INFO: Wrote provisioner from '../community-provisioners/llm-model/score-compose/10-dmr-llm-model-for-openai-clients.provisioners.yaml' to .score-compose/10-dmr-llm-model-for-openai-clients.gYBUL1s0n6j75cVc1I9hIg.provisioners.yaml
INFO: Wrote provisioner from '../community-provisioners/llm-model/score-compose/10-dmr-llm-model-via-curl-cmd.provisioners.yaml' to .score-compose/10-dmr-llm-model-via-curl-cmd.HJiu7Lxsxdd0QPk0-udrgQ.provisioners.yaml
INFO: Wrote provisioner from '../community-provisioners/llm-model/score-compose/10-dmr-llm-model-via-curl-service.provisioners.yaml' to .score-compose/10-dmr-llm-model-via-curl-service.wA20dasVU196KtMe1OU3yA.provisioners.yaml
INFO: Wrote provisioner from '../community-provisioners/llm-model/score-compose/10-dmr-llm-model-via-service-provider.provisioners.yaml' to .score-compose/10-dmr-llm-model-via-service-provider.IV_wQMhlmC8LksMt_FqMXA.provisioners.yaml
INFO: Wrote provisioner from '../community-provisioners/llm-model/score-compose/10-dmr-llm-model.provisioners.yaml' to .score-compose/10-dmr-llm-model.YbTvjVgmKwJXh2mEcSi3_A.provisioners.yaml
INFO: Wrote provisioner from '../community-provisioners/llm-model/score-compose/10-ollama-llm-model-service.provisioners.yaml' to .score-compose/10-ollama-llm-model-service.o4Oa8rS-sd_7YEMgkNwVwA.provisioners.yaml
INFO: Read more about the Score specification at https://docs.score.dev/docs/
```

**score-compose provisioners list**
```
./score-compose provisioners list
+-----------+-------+---------------------+---------------------+-----------------------------------------------------------------------------------------------------------+
|   TYPE    | CLASS |       PARAMS        |       OUTPUTS       |                                                DESCRIPTION                                                |
+-----------+-------+---------------------+---------------------+-----------------------------------------------------------------------------------------------------------+
| llm-model | (any) | context_size, model | api-key, model, url | Generates the LLM model via the Docker Model Runner (DMR). Outputs the url for OpenAI SDK/clients.        |
+-----------+-------+---------------------+---------------------+-----------------------------------------------------------------------------------------------------------+
| llm-model | (any) | model               | api-key, model, url | Runs curl to download the model with the Docker Model Runner (DMR).                                       |
+-----------+-------+---------------------+---------------------+-----------------------------------------------------------------------------------------------------------+
| llm-model | (any) | model               | api-key, model, url | Generates a curl service downloading the model with the Docker Model Runner (DMR).                        |
+-----------+-------+---------------------+---------------------+-----------------------------------------------------------------------------------------------------------+
| llm-model | (any) | model               | api-key, model, url | Generates the LLM model service via the Docker Model Runner (DMR) provider.                               |
+-----------+-------+---------------------+---------------------+-----------------------------------------------------------------------------------------------------------+
| llm-model | (any) | context_size, model | api-key, model, url | Generates the LLM model via the Docker Model Runner (DMR). Outputs the url for Ollama-compatible clients. |
+-----------+-------+---------------------+---------------------+-----------------------------------------------------------------------------------------------------------+
| llm-model | (any) | model               | api-key, model, url | Generates an Ollama service to pull a model from an existing local Ollama service.                        |
+-----------+-------+---------------------+---------------------+-----------------------------------------------------------------------------------------------------------+
```

#### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New chore (expected functionality to be implemented)

#### Checklist:

- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [x] I've signed off with an email address that matches the commit author.