### PR TITLE
fix: require at least one digit in CPU resource limit pattern

### DIFF
--- a/schema/files/score-v1b1.json
+++ b/schema/files/score-v1b1.json
@@ -189,7 +189,7 @@
         "cpu": {
           "description": "The CPU limit as whole or fractional CPUs. 'm' indicates milli-CPUs. For example 2 or 125m.",
           "type": "string",
-          "pattern": "^\\d*(?:m|\\.\\d+)?$"
+          "pattern": "^\\d+(?:m|\\.\\d+)?$"
         }
       }
     },

--- a/schema/files/score-v1b1.json.for-validation
+++ b/schema/files/score-v1b1.json.for-validation
@@ -189,7 +189,7 @@
         "cpu": {
           "description": "The CPU limit as whole or fractional CPUs. 'm' indicates milli-CPUs. For example 2 or 125m.",
           "type": "string",
-          "pattern": "^\\d*(?:m|\\.\\d+)?$"
+          "pattern": "^\\d+(?:m|\\.\\d+)?$"
         }
       }
     },


### PR DESCRIPTION
### Description
The CPU resource limit regex pattern currently accepts an empty string because `\d*` matches zero digits. This aligns the `score-go` schema with the fix in score-spec/spec#188.

### What does this PR do?
Changes the CPU pattern from `^\d*(?:m|\.\d+)?$` to `^\d+(?:m|\.\d+)?$` requiring at least one digit. Without this, an empty string passes validation which isn't a valid CPU value.

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] I've signed off with an email address that matches the commit author.
