### PR TITLE
feat: add directory support for git scheme in GetFiles

### DIFF
--- a/uriget/example_test.go
+++ b/uriget/example_test.go
@@ -22,6 +22,7 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -283,5 +284,112 @@ func TestGetFiles_DirectoryWithFileScheme(t *testing.T) {
 	}
 	if results[0].URI != filepath.Join(td, "a.yaml") || results[1].URI != filepath.Join(td, "b.yaml") {
 		t.Errorf("unexpected URIs: %s, %s", results[0].URI, results[1].URI)
+	}
+}
+
+func TestGetFiles_GitDirectory(t *testing.T) {
+	results, err := GetFiles(context.Background(), "git-https://github.com/score-spec/community-provisioners.git/dns/score-compose", WithLogger(log.New(os.Stderr, "", 0)))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(results) == 0 {
+		t.Fatal("expected at least one file from git directory")
+	}
+	// Verify files are sorted by name
+	for i := 1; i < len(results); i++ {
+		if results[i].URI < results[i-1].URI {
+			t.Errorf("results not sorted: %s came after %s", results[i].URI, results[i-1].URI)
+		}
+	}
+	// Verify all results have content
+	for _, r := range results {
+		if len(r.Content) == 0 {
+			t.Errorf("empty content for %s", r.URI)
+		}
+	}
+}
+
+func TestGetFiles_GitDirectoryWithTrailingSlash(t *testing.T) {
+	results, err := GetFiles(context.Background(), "git-https://github.com/score-spec/community-provisioners.git/dns/score-compose/", WithLogger(log.New(os.Stderr, "", 0)))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(results) == 0 {
+		t.Fatal("expected at least one file from git directory with trailing slash")
+	}
+}
+
+func TestGetFiles_GitSingleFile(t *testing.T) {
+	results, err := GetFiles(context.Background(), "git-https://github.com/score-spec/score.dev.git/README.md", WithLogger(log.New(os.Stderr, "", 0)))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(results) != 1 {
+		t.Fatalf("expected 1 result, got %d", len(results))
+	}
+	if len(results[0].Content) == 0 {
+		t.Error("expected non-empty content")
+	}
+}
+
+func TestGetFiles_GitDirectorySkipsSubdirs(t *testing.T) {
+	// The "dns" directory contains subdirectories (score-compose, score-k8s) and a file (score.yaml).
+	// Only the file should be returned, subdirectories should be skipped.
+	results, err := GetFiles(context.Background(), "git-https://github.com/score-spec/community-provisioners.git/dns", WithLogger(log.New(os.Stderr, "", 0)))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	for _, r := range results {
+		// URI should be a file path relative to the subPath, not contain nested dirs
+		if strings.Contains(r.URI, "/") && strings.HasPrefix(r.URI, "dns/") {
+			parts := strings.Split(strings.TrimPrefix(r.URI, "dns/"), "/")
+			if len(parts) > 1 {
+				t.Errorf("expected only immediate files, got nested path: %s", r.URI)
+			}
+		}
+	}
+}
+
+func TestGetFiles_GitInvalidUrl(t *testing.T) {
+	_, err := GetFiles(context.Background(), "git-https://github.com/score-spec/community-provisioners/dns", WithLogger(log.New(os.Stderr, "", 0)))
+	if err == nil {
+		t.Fatal("expected error for invalid git url without .git/, got nil")
+	}
+}
+
+func TestParseGitUrl(t *testing.T) {
+	tests := []struct {
+		name      string
+		rawUrl    string
+		wantSub   string
+		wantErr   bool
+	}{
+		{"file path", "git-https://github.com/org/repo.git/path/to/file.yaml", "path/to/file.yaml", false},
+		{"dir path", "git-https://github.com/org/repo.git/path/to/dir", "path/to/dir", false},
+		{"dir with trailing slash", "git-https://github.com/org/repo.git/path/to/dir/", "path/to/dir", false},
+		{"missing .git/", "git-https://github.com/org/repo/path", "", true},
+		{"empty subpath", "git-https://github.com/org/repo.git/", "", true},
+		{"empty repo", "git-https://.git/file", "", true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			u, err := url.Parse(tt.rawUrl)
+			if err != nil {
+				t.Fatalf("failed to parse url: %v", err)
+			}
+			_, subPath, err := parseGitUrl(u)
+			if tt.wantErr {
+				if err == nil {
+					t.Error("expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if subPath != tt.wantSub {
+				t.Errorf("expected subPath %q, got %q", tt.wantSub, subPath)
+			}
+		})
 	}
 }

--- a/uriget/uriget.go
+++ b/uriget/uriget.go
@@ -120,6 +120,8 @@ const ()
 // - file or no scheme: attempts to read the file from local file system.
 // - git-ssh / git-https: attempts to perform a sparse checkout of just the target file.
 // - oci: retrieves a file from a remote OCI registry based on the reference and optional fragment.
+//
+// Deprecated: Use GetFiles instead, which supports both single files and directories.
 func GetFile(ctx context.Context, rawUri string, optionFuncs ...Option) ([]byte, error) {
 	u, err := url.Parse(rawUri)
 	if err != nil {
@@ -144,10 +146,10 @@ func GetFile(ctx context.Context, rawUri string, optionFuncs ...Option) ([]byte,
 }
 
 // GetFiles is like GetFile but with support for importing multiple files from a directory. Currently, directory
-// support is only implemented for the file scheme. For other schemes (http, git, oci), the target is treated as a
+// support is implemented for the file and git schemes. For other schemes (http, oci), the target is treated as a
 // single file and returned as a single-element slice.
 //
-// TODO: Add directory support for git and oci schemes.
+// TODO: Add directory support for oci scheme.
 func GetFiles(ctx context.Context, rawUri string, optionFuncs ...Option) ([]FileContent, error) {
 	u, err := url.Parse(rawUri)
 	if err != nil {
@@ -164,7 +166,7 @@ func GetFiles(ctx context.Context, rawUri string, optionFuncs ...Option) ([]File
 	case "http", "https":
 		content, err = opts.getHttp(ctx, u)
 	case "git-ssh", "git-https":
-		content, err = opts.getGit(ctx, u)
+		return opts.getGitFileOrDir(ctx, u)
 	case "oci":
 		content, err = opts.getOci(ctx, u)
 	default:
@@ -342,49 +344,12 @@ func (o *options) getGit(ctx context.Context, u *url.URL) ([]byte, error) {
 	u.Path = parts[0] + ".git"
 	subPath := parts[1]
 
-	td, err := os.MkdirTemp(os.TempDir(), "score-go")
+	td, err := o.gitSparseCheckout(ctx, u.String(), subPath)
 	if err != nil {
-		return nil, fmt.Errorf("failed to make temp dir")
-	} else if err := os.Chmod(td, 0700); err != nil {
-		return nil, fmt.Errorf("failed to chown temp dir")
+		return nil, err
 	}
-	defer func() {
-		_ = os.RemoveAll(td)
-	}()
+	defer func() { _ = os.RemoveAll(td) }()
 
-	gitBinary, err := exec.LookPath("git")
-	if err != nil {
-		return nil, fmt.Errorf("failed to find git binary on the local system: %w", err)
-	}
-	gitRemote := "origin"
-	getRef := "HEAD"
-
-	c := exec.CommandContext(ctx, gitBinary, "init")
-	c.Dir = td
-	if output, err := c.CombinedOutput(); err != nil {
-		o.logger.Printf("command output: %s", output)
-		return nil, fmt.Errorf("failed to init git repo in %s: %w", td, err)
-	}
-	c = exec.CommandContext(ctx, gitBinary, "remote", "add", gitRemote, u.String())
-	c.Dir = td
-	if output, err := c.CombinedOutput(); err != nil {
-		o.logger.Printf("command output: %s", output)
-		return nil, fmt.Errorf("failed to set git remote to %s: %w", u.String(), err)
-	}
-	o.logger.Printf("Initialized git remote in %s for %s", td, u.String())
-	// https://stackoverflow.com/questions/61587133/cloning-single-file-from-git-repository
-	c = exec.CommandContext(ctx, gitBinary, "sparse-checkout", "set", "--no-cone", "--sparse-index", subPath)
-	c.Dir = td
-	if output, err := c.CombinedOutput(); err != nil {
-		o.logger.Printf("command output: %s", output)
-		return nil, fmt.Errorf("failed to set sparse checkout: %w", err)
-	}
-	c = exec.CommandContext(ctx, gitBinary, "pull", gitRemote, getRef, "--depth=1")
-	c.Dir = td
-	if output, err := c.CombinedOutput(); err != nil {
-		o.logger.Printf("command output: %s", output)
-		return nil, fmt.Errorf("failed to fetch: %w", err)
-	}
 	f, err := os.Open(filepath.Join(td, subPath))
 	if err != nil {
 		return nil, err
@@ -396,6 +361,128 @@ func (o *options) getGit(ctx context.Context, u *url.URL) ([]byte, error) {
 	}
 	o.logger.Printf("Read %d bytes from %s", len(buff), filepath.Join(td, subPath))
 	return buff, nil
+}
+
+// parseGitUrl parses a git URI and returns the remote URL and the sub-path within the repo.
+// It accepts paths with or without a trailing slash.
+func parseGitUrl(u *url.URL) (remoteUrl string, subPath string, err error) {
+	u.Scheme = strings.TrimPrefix(u.Scheme, "git-")
+	u.RawQuery = ""
+	u.Fragment = ""
+	parts := strings.SplitN(u.Path, ".git/", 2)
+	if len(parts) == 1 || parts[0] == "" || parts[1] == "" {
+		return "", "", fmt.Errorf("invalid git url, expected a path with ../<REPO>.git/<PATH>")
+	}
+	u.Path = parts[0] + ".git"
+	subPath = strings.TrimSuffix(parts[1], "/")
+	return u.String(), subPath, nil
+}
+
+// gitSparseCheckout performs a sparse checkout of the given subPath from the git remote into a temp directory.
+// The caller is responsible for cleaning up the returned temp directory.
+func (o *options) gitSparseCheckout(ctx context.Context, remoteUrl string, subPath string) (string, error) {
+	td, err := os.MkdirTemp(os.TempDir(), "score-go")
+	if err != nil {
+		return "", fmt.Errorf("failed to make temp dir")
+	} else if err := os.Chmod(td, 0700); err != nil {
+		_ = os.RemoveAll(td)
+		return "", fmt.Errorf("failed to chown temp dir")
+	}
+
+	gitBinary, err := exec.LookPath("git")
+	if err != nil {
+		_ = os.RemoveAll(td)
+		return "", fmt.Errorf("failed to find git binary on the local system: %w", err)
+	}
+
+	for _, step := range []struct {
+		args   []string
+		errMsg string
+	}{
+		{[]string{"init"}, "failed to init git repo in " + td},
+		{[]string{"remote", "add", "origin", remoteUrl}, "failed to set git remote to " + remoteUrl},
+		{[]string{"sparse-checkout", "set", "--no-cone", "--sparse-index", subPath}, "failed to set sparse checkout"},
+		{[]string{"pull", "origin", "HEAD", "--depth=1"}, "failed to fetch"},
+	} {
+		c := exec.CommandContext(ctx, gitBinary, step.args...)
+		c.Dir = td
+		if output, err := c.CombinedOutput(); err != nil {
+			o.logger.Printf("command output: %s", output)
+			_ = os.RemoveAll(td)
+			return "", fmt.Errorf("%s: %w", step.errMsg, err)
+		}
+	}
+	o.logger.Printf("Initialized git remote in %s for %s", td, remoteUrl)
+	return td, nil
+}
+
+// getGitFileOrDir is like getGit but returns multiple files if the subPath is a directory.
+func (o *options) getGitFileOrDir(ctx context.Context, u *url.URL) ([]FileContent, error) {
+	originalUri := u.String()
+	remoteUrl, subPath, err := parseGitUrl(u)
+	if err != nil {
+		return nil, err
+	}
+
+	td, err := o.gitSparseCheckout(ctx, remoteUrl, subPath)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = os.RemoveAll(td) }()
+
+	fullPath := filepath.Join(td, subPath)
+	info, err := os.Stat(fullPath)
+	if err != nil {
+		return nil, err
+	}
+
+	if !info.IsDir() {
+		f, err := os.Open(fullPath)
+		if err != nil {
+			return nil, err
+		}
+		defer func() { _ = f.Close() }()
+		buff, err := readLimited(f, o.limit)
+		if err != nil {
+			return nil, fmt.Errorf("failed to read file: %w", err)
+		}
+		o.logger.Printf("Read %d bytes from %s", len(buff), fullPath)
+		return []FileContent{{URI: originalUri, Content: buff}}, nil
+	}
+
+	entries, err := os.ReadDir(fullPath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read directory: %w", err)
+	}
+
+	var fileNames []string
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			fileNames = append(fileNames, entry.Name())
+		}
+	}
+	sort.Strings(fileNames)
+
+	if len(fileNames) == 0 {
+		return nil, fmt.Errorf("directory %s contains no files", subPath)
+	}
+
+	var out []FileContent
+	for _, name := range fileNames {
+		filePath := filepath.Join(fullPath, name)
+		f, err := os.Open(filePath)
+		if err != nil {
+			return nil, fmt.Errorf("failed to open %s: %w", filePath, err)
+		}
+		buff, err := readLimited(f, o.limit)
+		_ = f.Close()
+		if err != nil {
+			return nil, fmt.Errorf("failed to read %s: %w", filePath, err)
+		}
+		o.logger.Printf("Read %d bytes from %s", len(buff), filePath)
+		out = append(out, FileContent{URI: subPath + "/" + name, Content: buff})
+	}
+	return out, nil
 }
 
 func (o *options) getOci(ctx context.Context, u *url.URL) ([]byte, error) {


### PR DESCRIPTION
#### Description

Closes #184

#### What does this PR do?

Extends `GetFiles` to support fetching multiple files from a directory in a git repository via `git-ssh://` and `git-https://` URIs.

The implementation:
- Extracts git sparse-checkout logic into a reusable `gitSparseCheckout` helper (shared by both `getGit` and `getGitFileOrDir`)
- Adds `parseGitUrl` that accepts paths with or without trailing slash
- Adds `getGitFileOrDir` that auto-detects file vs directory after checkout using `os.Stat`
- For directories: reads immediate files (non-recursive), sorted by name — consistent with the existing local directory behavior in `getFileOrDir`
- For single files: returns a single-element slice (backward compatible)
- Marks `GetFile` as deprecated in favor of `GetFiles`
- Updates the TODO comment to only reference the `oci` scheme

Example usage:

git-https://github.com/org/repo.git/path/to/directory
git-ssh://git@github.com/org/repo.git/path/to/directory/

#### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New chore (expected functionality to be implemented)

#### Checklist:

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've signed off with an email address that matches the commit author.

#### Testing Evidence

Tested by pointing `score-compose` (latest `main`) and `score-k8s` (latest `main`) to this branch's commit (`47325e2`) via `go mod replace`.

**score-compose — git directory (provisioners)**

```
$ score-compose init --provisioners "git-https://github.com/score-spec/community-provisioners.git/dns/score-compose"
INFO: Writing new state directory '.score-compose'
INFO: Writing new state directory '.score-compose' with project name 'score-test-compose'
INFO: Writing default provisioners file
INFO: Initial Score file './score.yaml' does not exist - creating it
INFO: Initialized git remote in /var/folders/.../score-go1866053434 for https://github.com/score-spec/community-provisioners.git
INFO: Read 450 bytes from .../dns/score-compose/10-dns-in-codespace.provisioners.yaml
INFO: Read 483 bytes from .../dns/score-compose/10-dns-with-url.provisioners.yaml
INFO: Read 150 bytes from .../dns/score-compose/README.md
INFO: Wrote provisioner from 'dns/score-compose/10-dns-in-codespace.provisioners.yaml' to .score-compose/...provisioners.yaml
INFO: Wrote provisioner from 'dns/score-compose/10-dns-with-url.provisioners.yaml' to .score-compose/...provisioners.yaml
Error: failed to save provisioner from dns/score-compose/README.md: invalid provisioners file: ...
```

Directory fetching works — all 3 files read. Error is expected (README.md is not a valid provisioner).

**score-compose — single file (backward compatibility)**

```
$ score-compose init --provisioners "git-https://github.com/score-spec/community-provisioners.git/dns/score-compose/10-dns-with-
url.provisioners.yaml"
INFO: Initialized git remote in /var/folders/.../score-go3557785138 for https://github.com/score-spec/community-provisioners.git
INFO: Read 483 bytes from .../dns/score-compose/10-dns-with-url.provisioners.yaml
INFO: Wrote provisioner from 'git-https://...10-dns-with-url.provisioners.yaml' to .score-compose/...provisioners.yaml
INFO: Read more about the Score specification at https://docs.score.dev/docs/
```

Single file still works as before.

**score-k8s — git directory (patch templates)**

```
$ score-k8s init --patch-templates "git-https://github.com/score-spec/community-patchers.git/score-k8s"
INFO: Fetching patch template from git-https://github.com/score-spec/community-patchers.git/score-k8s
INFO: Initialized git remote in /var/folders/.../score-go3211411837 for https://github.com/score-spec/community-patchers.git
INFO: Read 3856 bytes from .../score-k8s/backstage-catalog-entities.tpl
INFO: Read 450 bytes from .../score-k8s/delete-default-manifests.tpl
INFO: Read 743 bytes from .../score-k8s/knative-service.tpl
INFO: Read 184 bytes from .../score-k8s/namespace-pss-restricted.tpl
INFO: Read 439 bytes from .../score-k8s/namespace-with-allow-ingress-within-namespace-netpol.tpl
INFO: Read 289 bytes from .../score-k8s/namespace-with-deny-all-netpol.tpl
INFO: Read 849 bytes from .../score-k8s/service-account-admin.tpl
INFO: Read 419 bytes from .../score-k8s/service-account.tpl
INFO: Read 298 bytes from .../score-k8s/statefulset.tpl
INFO: Read 680 bytes from .../score-k8s/unprivileged.tpl
INFO: Writing new state directory
INFO: Created default provisioners file
INFO: Created initial Score file
INFO: Read more about the Score specification at https://docs.score.dev/docs/
```
All 10 patch template files fetched from directory successfully.