### PR TITLE
feat: add NewSubstituterWithDelimiters for custom placeholder pairs

### DIFF
--- a/framework/substitution.go
+++ b/framework/substitution.go
@@ -42,11 +42,8 @@ func SplitRefParts(ref string) []string {
 // default to simply replacing sequences of $$ with a $.
 // Overriding the UnEscaper may be necessary if non default behavior is required.
 //
-// CustomRegex, when non-nil, replaces the default ${...} placeholder pattern with the given regular
-// expression. The first capture group of CustomRegex must contain the placeholder content, which is
-// passed verbatim to Replacer. When CustomRegex is set, no escape handling is performed (UnEscaper
-// is ignored): every match is treated as a placeholder. Use NewSubstituterWithDelimiters to obtain
-// a Substituter with custom start/end delimiters.
+// CustomRegex, when non-nil, replaces the default ${...} pattern. Its first capture group is the
+// placeholder content passed to Replacer, and UnEscaper is ignored in this mode.
 type Substituter struct {
 	Replacer    func(string) (string, error)
 	UnEscaper   func(string) (string, error)
@@ -54,14 +51,9 @@ type Substituter struct {
 }
 
 // NewSubstituterWithDelimiters returns a Substituter that matches placeholders bounded by the given
-// start and end delimiters instead of the default "${" and "}". The placeholder content (everything
-// between start and end, matched non-greedily) is passed to Replacer.
-//
-// No escape mechanism is provided in this mode: choose delimiters that do not appear literally in
-// the input text that should be left unmodified. Both start and end must be non-empty.
-//
-// The returned Substituter has CustomRegex set but no Replacer; callers must assign Replacer before
-// invoking SubstituteString or Substitute.
+// start and end delimiters (matched non-greedily) instead of the default "${" and "}". Both must be
+// non-empty. There is no escape mechanism, so choose delimiters that do not appear literally in the
+// input. The returned Substituter has no Replacer; callers must assign one before use.
 func NewSubstituterWithDelimiters(start, end string) (*Substituter, error) {
 	if start == "" {
 		return nil, errors.New("start delimiter must not be empty")
@@ -120,8 +112,6 @@ func (s *Substituter) SubstituteString(src string) (string, error) {
 	return result, err
 }
 
-// substituteWithCustomRegex performs substitution using the user-supplied CustomRegex. No escape
-// handling is applied; every match is passed straight to Replacer using the first capture group.
 func (s *Substituter) substituteWithCustomRegex(src string) (string, error) {
 	var err error
 	result := s.CustomRegex.ReplaceAllStringFunc(src, func(str string) string {
@@ -180,9 +170,8 @@ func Substitute(source interface{}, inner func(string) (string, error)) (interfa
 	return (&Substituter{Replacer: inner, UnEscaper: DefaultUnEscaper}).Substitute(source)
 }
 
-// SubstituteStringWithDelimiters replaces all matches of the given start/end delimiter pair in the
-// source string with the result of the inner function. No escape mechanism is provided: choose
-// delimiters that do not appear literally in input that should be left unmodified.
+// SubstituteStringWithDelimiters is like SubstituteString but uses the given start/end delimiter
+// pair instead of "${" and "}". No escape handling; the delimiters must not appear in the input.
 func SubstituteStringWithDelimiters(src, start, end string, inner func(string) (string, error)) (string, error) {
 	s, err := NewSubstituterWithDelimiters(start, end)
 	if err != nil {

--- a/framework/substitution.go
+++ b/framework/substitution.go
@@ -50,10 +50,7 @@ type Substituter struct {
 	CustomRegex *regexp.Regexp
 }
 
-// NewSubstituterWithDelimiters returns a Substituter that matches placeholders bounded by the given
-// start and end delimiters (matched non-greedily) instead of the default "${" and "}". Both must be
-// non-empty. There is no escape mechanism, so choose delimiters that do not appear literally in the
-// input. The returned Substituter has no Replacer; callers must assign one before use.
+// Add a Substituter constructor that takes custom start/end delimiters instead of the hardcoded ${ and }.
 func NewSubstituterWithDelimiters(start, end string) (*Substituter, error) {
 	if start == "" {
 		return nil, errors.New("start delimiter must not be empty")

--- a/framework/substitution.go
+++ b/framework/substitution.go
@@ -41,9 +41,8 @@ func SplitRefParts(ref string) []string {
 // function is _required_ and the substituter will not function without it, but the UnEscaper is optional and will
 // default to simply replacing sequences of $$ with a $.
 // Overriding the UnEscaper may be necessary if non default behavior is required.
-//
-// CustomRegex, when non-nil, replaces the default ${...} pattern. Its first capture group is the
-// placeholder content passed to Replacer, and UnEscaper is ignored in this mode.
+
+// Add a CustomRegex option that overrides the default ${...} matching first capture group is the placeholder, and UnEscaper is skipped when it's set.
 type Substituter struct {
 	Replacer    func(string) (string, error)
 	UnEscaper   func(string) (string, error)
@@ -167,8 +166,7 @@ func Substitute(source interface{}, inner func(string) (string, error)) (interfa
 	return (&Substituter{Replacer: inner, UnEscaper: DefaultUnEscaper}).Substitute(source)
 }
 
-// SubstituteStringWithDelimiters is like SubstituteString but uses the given start/end delimiter
-// pair instead of "${" and "}". No escape handling; the delimiters must not appear in the input.
+// Add SubstituteStringWithDelimiters, a version of SubstituteString that takes custom delimiters instead of ${ / } (no escaping, so the delimiters can't appear in the input).
 func SubstituteStringWithDelimiters(src, start, end string, inner func(string) (string, error)) (string, error) {
 	s, err := NewSubstituterWithDelimiters(start, end)
 	if err != nil {

--- a/framework/substitution.go
+++ b/framework/substitution.go
@@ -41,9 +41,40 @@ func SplitRefParts(ref string) []string {
 // function is _required_ and the substituter will not function without it, but the UnEscaper is optional and will
 // default to simply replacing sequences of $$ with a $.
 // Overriding the UnEscaper may be necessary if non default behavior is required.
+//
+// CustomRegex, when non-nil, replaces the default ${...} placeholder pattern with the given regular
+// expression. The first capture group of CustomRegex must contain the placeholder content, which is
+// passed verbatim to Replacer. When CustomRegex is set, no escape handling is performed (UnEscaper
+// is ignored): every match is treated as a placeholder. Use NewSubstituterWithDelimiters to obtain
+// a Substituter with custom start/end delimiters.
 type Substituter struct {
-	Replacer  func(string) (string, error)
-	UnEscaper func(string) (string, error)
+	Replacer    func(string) (string, error)
+	UnEscaper   func(string) (string, error)
+	CustomRegex *regexp.Regexp
+}
+
+// NewSubstituterWithDelimiters returns a Substituter that matches placeholders bounded by the given
+// start and end delimiters instead of the default "${" and "}". The placeholder content (everything
+// between start and end, matched non-greedily) is passed to Replacer.
+//
+// No escape mechanism is provided in this mode: choose delimiters that do not appear literally in
+// the input text that should be left unmodified. Both start and end must be non-empty.
+//
+// The returned Substituter has CustomRegex set but no Replacer; callers must assign Replacer before
+// invoking SubstituteString or Substitute.
+func NewSubstituterWithDelimiters(start, end string) (*Substituter, error) {
+	if start == "" {
+		return nil, errors.New("start delimiter must not be empty")
+	}
+	if end == "" {
+		return nil, errors.New("end delimiter must not be empty")
+	}
+	pattern := regexp.QuoteMeta(start) + "(.*?)" + regexp.QuoteMeta(end)
+	re, err := regexp.Compile(pattern)
+	if err != nil {
+		return nil, fmt.Errorf("failed to build delimiter regex from start=%q end=%q: %w", start, end, err)
+	}
+	return &Substituter{CustomRegex: re}, nil
 }
 
 func DefaultUnEscaper(original string) (string, error) {
@@ -53,6 +84,9 @@ func DefaultUnEscaper(original string) (string, error) {
 func (s *Substituter) SubstituteString(src string) (string, error) {
 	if s.Replacer == nil {
 		return "", errors.New("replacer function is nil")
+	}
+	if s.CustomRegex != nil {
+		return s.substituteWithCustomRegex(src)
 	}
 	var err error
 	result := placeholderRegEx.ReplaceAllStringFunc(src, func(str string) string {
@@ -82,6 +116,23 @@ func (s *Substituter) SubstituteString(src string) (string, error) {
 		result, subErr := s.Replacer(matches[2])
 		err = errors.Join(err, subErr)
 		return result
+	})
+	return result, err
+}
+
+// substituteWithCustomRegex performs substitution using the user-supplied CustomRegex. No escape
+// handling is applied; every match is passed straight to Replacer using the first capture group.
+func (s *Substituter) substituteWithCustomRegex(src string) (string, error) {
+	var err error
+	result := s.CustomRegex.ReplaceAllStringFunc(src, func(str string) string {
+		matches := s.CustomRegex.FindStringSubmatch(str)
+		if len(matches) < 2 {
+			err = errors.Join(err, fmt.Errorf("custom placeholder regex must define at least one capture group for the placeholder content"))
+			return str
+		}
+		res, subErr := s.Replacer(matches[1])
+		err = errors.Join(err, subErr)
+		return res
 	})
 	return result, err
 }
@@ -127,6 +178,18 @@ func SubstituteString(src string, inner func(string) (string, error)) (string, e
 // Substitute does the same thing as SubstituteString but recursively through a map. It returns a copy of the original map.
 func Substitute(source interface{}, inner func(string) (string, error)) (interface{}, error) {
 	return (&Substituter{Replacer: inner, UnEscaper: DefaultUnEscaper}).Substitute(source)
+}
+
+// SubstituteStringWithDelimiters replaces all matches of the given start/end delimiter pair in the
+// source string with the result of the inner function. No escape mechanism is provided: choose
+// delimiters that do not appear literally in input that should be left unmodified.
+func SubstituteStringWithDelimiters(src, start, end string, inner func(string) (string, error)) (string, error) {
+	s, err := NewSubstituterWithDelimiters(start, end)
+	if err != nil {
+		return "", err
+	}
+	s.Replacer = inner
+	return s.SubstituteString(src)
 }
 
 func mapLookupOutput(ctx map[string]interface{}) func(keys ...string) (interface{}, error) {

--- a/framework/substitution_test.go
+++ b/framework/substitution_test.go
@@ -203,9 +203,8 @@ func TestNewSubstituterWithDelimiters_validation(t *testing.T) {
 	}
 }
 
-// TestSubstituterWithDelimiters_pairs runs a set of (start, end) pairs through the substituter
-// and checks that placeholders match, surrounding text is preserved, and literal ${...} (the
-// default Score syntax) is left alone whenever custom delimiters are in use.
+// TestSubstituterWithDelimiters_pairs covers a matrix of delimiter pairs and confirms that the
+// default ${...} syntax is left alone when custom delimiters are in use.
 func TestSubstituterWithDelimiters_pairs(t *testing.T) {
 	upper := func(s string) (string, error) { return strings.ToUpper(s), nil }
 	for _, tc := range []struct {
@@ -292,8 +291,6 @@ func TestSubstituterWithDelimiters_pairs(t *testing.T) {
 	}
 }
 
-// TestSubstituterWithDelimiters_propagatesReplacerError ensures that errors returned by the
-// replacer are surfaced (not swallowed) when running with custom delimiters.
 func TestSubstituterWithDelimiters_propagatesReplacerError(t *testing.T) {
 	s, err := NewSubstituterWithDelimiters("%{", "}")
 	assert.NoError(t, err)
@@ -302,8 +299,6 @@ func TestSubstituterWithDelimiters_propagatesReplacerError(t *testing.T) {
 	assert.EqualError(t, err, "nope")
 }
 
-// TestSubstituterWithDelimiters_nilReplacer: a nil Replacer should produce an error, not a
-// panic, same as the default-mode path.
 func TestSubstituterWithDelimiters_nilReplacer(t *testing.T) {
 	s, err := NewSubstituterWithDelimiters("%{", "}")
 	assert.NoError(t, err)
@@ -311,7 +306,6 @@ func TestSubstituterWithDelimiters_nilReplacer(t *testing.T) {
 	assert.EqualError(t, err, "replacer function is nil")
 }
 
-// TestSubstituteStringWithDelimiters covers the package-level convenience function.
 func TestSubstituteStringWithDelimiters(t *testing.T) {
 	out, err := SubstituteStringWithDelimiters("hi %{x} %{y}", "%{", "}",
 		func(s string) (string, error) { return "<" + s + ">", nil })
@@ -322,8 +316,8 @@ func TestSubstituteStringWithDelimiters(t *testing.T) {
 	assert.EqualError(t, err, "start delimiter must not be empty")
 }
 
-// TestDefaultPathUnchanged is a regression guard: when CustomRegex is not set, output must match
-// the previous SubstituteString behavior for a representative sample of inputs.
+// TestDefaultPathUnchanged is a regression guard: when CustomRegex is unset, output must match
+// the previous SubstituteString behavior.
 func TestDefaultPathUnchanged(t *testing.T) {
 	for _, tc := range []struct {
 		Input    string

--- a/framework/substitution_test.go
+++ b/framework/substitution_test.go
@@ -183,3 +183,163 @@ func TestCustomerUnescaper(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, "$$$$ $${thing}$${thing}", x)
 }
+
+func TestNewSubstituterWithDelimiters_validation(t *testing.T) {
+	for _, tc := range []struct {
+		Name          string
+		Start         string
+		End           string
+		ExpectedError string
+	}{
+		{Name: "empty start", Start: "", End: "}", ExpectedError: "start delimiter must not be empty"},
+		{Name: "empty end", Start: "${", End: "", ExpectedError: "end delimiter must not be empty"},
+		{Name: "both empty", Start: "", End: "", ExpectedError: "start delimiter must not be empty"},
+	} {
+		t.Run(tc.Name, func(t *testing.T) {
+			s, err := NewSubstituterWithDelimiters(tc.Start, tc.End)
+			assert.Nil(t, s)
+			assert.EqualError(t, err, tc.ExpectedError)
+		})
+	}
+}
+
+// TestSubstituterWithDelimiters_pairs runs a set of (start, end) pairs through the substituter
+// and checks that placeholders match, surrounding text is preserved, and literal ${...} (the
+// default Score syntax) is left alone whenever custom delimiters are in use.
+func TestSubstituterWithDelimiters_pairs(t *testing.T) {
+	upper := func(s string) (string, error) { return strings.ToUpper(s), nil }
+	for _, tc := range []struct {
+		Name     string
+		Start    string
+		End      string
+		Input    string
+		Expected string
+	}{
+		{
+			Name:     "default-style ${ }",
+			Start:    "${",
+			End:      "}",
+			Input:    "hello ${name}",
+			Expected: "hello NAME",
+		},
+		{
+			Name:     "percent %{ }",
+			Start:    "%{",
+			End:      "}",
+			Input:    "hello %{name} and ${untouched}",
+			Expected: "hello NAME and ${untouched}",
+		},
+		{
+			Name:     "angle << >>",
+			Start:    "<<",
+			End:      ">>",
+			Input:    "echo <<USER>> ${HOME}",
+			Expected: "echo USER ${HOME}",
+		},
+		{
+			Name:     "asymmetric <%{ }%>",
+			Start:    "<%{",
+			End:      "}%>",
+			Input:    "value=<%{resources.db.host}%>; literal=${DB_PORT}",
+			Expected: "value=RESOURCES.DB.HOST; literal=${DB_PORT}",
+		},
+		{
+			Name:     "double-brace [[ ]]",
+			Start:    "[[",
+			End:      "]]",
+			Input:    "a [[x]] b [[y]] c",
+			Expected: "a X b Y c",
+		},
+		{
+			Name:     "no matches leaves input untouched",
+			Start:    "%{",
+			End:      "}",
+			Input:    "no placeholders here, just ${dollar} and {bare}",
+			Expected: "no placeholders here, just ${dollar} and {bare}",
+		},
+		{
+			Name:     "empty content is matched",
+			Start:    "%{",
+			End:      "}",
+			Input:    "before %{} after",
+			Expected: "before  after",
+		},
+		{
+			Name:     "regex metacharacters in delimiters are escaped",
+			Start:    "$(",
+			End:      ")",
+			Input:    "shell $(cmd) here",
+			Expected: "shell CMD here",
+		},
+		{
+			Name:     "non-greedy matching across multiple placeholders",
+			Start:    "<<",
+			End:      ">>",
+			Input:    "<<a>> middle <<b>>",
+			Expected: "A middle B",
+		},
+	} {
+		t.Run(tc.Name, func(t *testing.T) {
+			s, err := NewSubstituterWithDelimiters(tc.Start, tc.End)
+			if !assert.NoError(t, err) {
+				return
+			}
+			s.Replacer = upper
+			res, err := s.SubstituteString(tc.Input)
+			assert.NoError(t, err)
+			assert.Equal(t, tc.Expected, res)
+		})
+	}
+}
+
+// TestSubstituterWithDelimiters_propagatesReplacerError ensures that errors returned by the
+// replacer are surfaced (not swallowed) when running with custom delimiters.
+func TestSubstituterWithDelimiters_propagatesReplacerError(t *testing.T) {
+	s, err := NewSubstituterWithDelimiters("%{", "}")
+	assert.NoError(t, err)
+	s.Replacer = func(string) (string, error) { return "", fmt.Errorf("nope") }
+	_, err = s.SubstituteString("a %{x} b")
+	assert.EqualError(t, err, "nope")
+}
+
+// TestSubstituterWithDelimiters_nilReplacer: a nil Replacer should produce an error, not a
+// panic, same as the default-mode path.
+func TestSubstituterWithDelimiters_nilReplacer(t *testing.T) {
+	s, err := NewSubstituterWithDelimiters("%{", "}")
+	assert.NoError(t, err)
+	_, err = s.SubstituteString("%{x}")
+	assert.EqualError(t, err, "replacer function is nil")
+}
+
+// TestSubstituteStringWithDelimiters covers the package-level convenience function.
+func TestSubstituteStringWithDelimiters(t *testing.T) {
+	out, err := SubstituteStringWithDelimiters("hi %{x} %{y}", "%{", "}",
+		func(s string) (string, error) { return "<" + s + ">", nil })
+	assert.NoError(t, err)
+	assert.Equal(t, "hi <x> <y>", out)
+
+	_, err = SubstituteStringWithDelimiters("anything", "", "}", nil)
+	assert.EqualError(t, err, "start delimiter must not be empty")
+}
+
+// TestDefaultPathUnchanged is a regression guard: when CustomRegex is not set, output must match
+// the previous SubstituteString behavior for a representative sample of inputs.
+func TestDefaultPathUnchanged(t *testing.T) {
+	for _, tc := range []struct {
+		Input    string
+		Expected string
+	}{
+		{Input: "", Expected: ""},
+		{Input: "abc", Expected: "abc"},
+		{Input: "$abc", Expected: "$abc"},
+		{Input: "abc $$ abc", Expected: "abc $ abc"},
+		{Input: "$${abc}", Expected: "${abc}"},
+		{Input: "my name is ${metadata.name}", Expected: "my name is test-name"},
+	} {
+		t.Run(tc.Input, func(t *testing.T) {
+			res, err := SubstituteString(tc.Input, substitutionFunction)
+			assert.NoError(t, err)
+			assert.Equal(t, tc.Expected, res)
+		})
+	}
+}


### PR DESCRIPTION
#### Description
Lets callers configure a custom start/end delimiter pair on the `Substituter`, so patterns like `%{var}`, `<<var>>`, or `<%{var}%>` work as placeholders instead of being tied to `${var}`. This is the score-go half of score-spec/spec#108. The score-compose change that actually surfaces this to end users (via workload annotations) will land in a separate PR that depends on a tagged release of this one.

The zero-value `Substituter{}` and the existing `SubstituteString` / `Substitute` package functions behave exactly as before. `TestDefaultPathUnchanged` guards that explicitly.

#### What does this PR do?
Three additions, none of them on the default path:

- A `CustomRegex *regexp.Regexp` field on `Substituter`. When non-nil it replaces the default `${...}` regex; the first capture group is treated as the placeholder content and passed to `Replacer`.
- `NewSubstituterWithDelimiters(start, end string) (*Substituter, error)`, which builds the regex from `regexp.QuoteMeta(start) + "(.*?)" + regexp.QuoteMeta(end)` and rejects empty inputs.
- A package-level `SubstituteStringWithDelimiters` matching the existing `SubstituteString` shape.

There's no escape mechanism in custom-delimiter mode. Discussion on the parent issue worked through why: a doubled-prefix escape doesn't extend cleanly to asymmetric pairs like `<<` / `>>` or `<%{` / `}%>`, and a backslash escape was set aside until someone actually hits the wall. Documented constraint for now is that the chosen delimiters shouldn't appear literally in the file.

Tests cover a matrix of delimiter pairs (`${ }`, `%{ }`, `<< >>`, `<%{ }%>`, `[[ ]]`, `$( )`), regex metacharacters inside delimiters, non-greedy matching across multiple placeholders, the no-match passthrough case, empty-content matches, replacer error propagation, the nil-replacer guard, and a regression check that the default path produces the same output as before.

Refs: score-spec/spec#108

#### Types of changes
- [x] New feature (non-breaking change which adds functionality)

#### Checklist
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I've signed off with an email address that matches the commit author.