### PR TITLE
framework: return error instead of panicking on out-of-range array index

### DIFF
--- a/framework/override_utils.go
+++ b/framework/override_utils.go
@@ -145,6 +145,10 @@ func overridePathInArray(input []interface{}, path []string, isDelete bool, valu
 		return output, nil
 	}
 
+	if pathIndex < 0 || pathIndex >= len(output) {
+		return nil, fmt.Errorf("cannot set '%d' in array: out of range", pathIndex)
+	}
+
 	switch typed := output[pathIndex].(type) {
 	case map[string]interface{}:
 		subOutput, err := overridePathInMap(typed, path[1:], isDelete, value)

--- a/framework/override_utils_test.go
+++ b/framework/override_utils_test.go
@@ -107,6 +107,20 @@ func TestWritePathInStruct(t *testing.T) {
 			ExpectedError: fmt.Errorf("a: cannot set '2' in array: out of range"),
 		},
 		{
+			Name:          "nested index out of range",
+			Spec:          `{"a": [{}]}`,
+			Path:          []string{"a", "2", "c"},
+			Value:         "hello",
+			ExpectedError: fmt.Errorf("a: cannot set '2' in array: out of range"),
+		},
+		{
+			Name:          "nested negative index",
+			Spec:          `{"a": [{}]}`,
+			Path:          []string{"a", "-1", "c"},
+			Value:         "hello",
+			ExpectedError: fmt.Errorf("a: cannot set '-1' in array: out of range"),
+		},
+		{
 			Name:     "no append nested arrays",
 			Spec:     `{"a":[[0]]}`,
 			Path:     []string{"a", "0", "-1"},


### PR DESCRIPTION
`overridePathInArray` only bounds-checks the array index in the terminal (`len(path) == 1`) branch. When the override path continues past the index, it falls through to `output[pathIndex]` with no check, so an override such as `volumes.3.source` against a shorter array panics with `index out of range` (a negative index like `volumes.-1.source` panics too). Since `--override-property` values flow straight into `OverridePathInMap`, a typo'd index crashes the CLIs with a Go stack trace instead of the usual friendly error.

This adds the same out-of-range check the terminal branch already returns, before the type switch. Added two table cases (`nested index out of range`, `nested negative index`) that panic on main and now return `cannot set 'N' in array: out of range`.

Fixes #202